### PR TITLE
Enclose the cordova notification polyfills within a browser-detection discriminator.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -131,27 +131,3 @@ if (!Function.prototype.bind) {
     return fBound;
   };
 }
-
-/* Function.bind polyfill */
-
-if (!Function.prototype.bind) {
-  Function.prototype.bind = function (oThis) {
-    if (typeof this !== "function") {
-      // closest thing possible to the ECMAScript 5 internal IsCallable function
-      throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
-    }
- 
-    var aArgs = Array.prototype.slice.call(arguments, 1),
-        fToBind = this,
-        FNOP = function () {},
-        fBound = function () {
-          return fToBind.apply(this instanceof FNOP && oThis ? this : oThis,
-                               aArgs.concat(Array.prototype.slice.call(arguments)));
-        };
- 
-    FNOP.prototype = this.prototype;
-    fBound.prototype = new FNOP();
- 
-    return fBound;
-  };
-}


### PR DESCRIPTION
Tommy, please suggest a better way to detect the absence of Cordova, if there is one.
