### PR TITLE
Prevent seemingly spurious "RangeError: Maximum call stack size exceeded."

### DIFF
--- a/www/tests/index.html
+++ b/www/tests/index.html
@@ -50,7 +50,7 @@
       mocha.ui('bdd');
       mocha.reporter('html');
       mocha.setup({ignoreLeaks: true});
-      should = chai.should();
+      var should = chai.should();
     </script>
     <script src="./SpiderOakMobile-tests.js"></script>
     <script>


### PR DESCRIPTION
A tiny fix to prevent this spurious error message when testing.
@devgeeks, see https://github.com/chaijs/chai/issues/107
