### PR TITLE
Wrap notification polyfills in a decent test for the absence of cordova, so ...

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -82,29 +82,31 @@
 
 /* Cordova polyfills */
 
-if (! navigator.notification) {
-  navigator.notification = {};
-}
+if (! window.cordova) {
+  if (! navigator.notification) {
+    navigator.notification = {};
+  }
 
-if (! navigator.notification.alert) {
-  navigator.notification.alert =
-      function (message, alertCallback, title, buttonName) {
-        window.alert(message);
-        if (alertCallback) {
+  if (! navigator.notification.alert) {
+    navigator.notification.alert =
+        function (message, alertCallback, title, buttonName) {
+          window.alert(message);
+          if (alertCallback) {
             alertCallback();
-        }
-    };
-}
+          }
+        };
+  }
 
-if (! navigator.notification.confirm) {
-  navigator.notification.confirm =
-      function (message, confirmCallback, title, buttonLabels){
-        var isConfirmed = window.confirm(message);
-        if (confirmCallback)
-        {
-          confirmCallback((isConfirmed) ? 1 : 2);
-        }
-      };
+  if (! navigator.notification.confirm) {
+    navigator.notification.confirm =
+        function (message, confirmCallback, title, buttonLabels){
+          var isConfirmed = window.confirm(message);
+          if (confirmCallback)
+          {
+            confirmCallback((isConfirmed) ? 1 : 2);
+          }
+        };
+  }
 }
 
 /* Function.bind polyfill */


### PR DESCRIPTION
they don't override the cordova functions, which may happen after app.js is
evaluated.

This branch almost exactly the same stuff as the prior one of the same name, but without all the merge/rebase baggage.
