### PR TITLE
Relocate the cordova polyfills in a dedicated file, and load it immediately...

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -88,33 +88,6 @@
 
 /* Cordova polyfills */
 
-if (! window.cordova) {
-  if (! navigator.notification) {
-    navigator.notification = {};
-  }
-
-  if (! navigator.notification.alert) {
-    navigator.notification.alert =
-        function (message, alertCallback, title, buttonName) {
-          window.alert(message);
-          if (alertCallback) {
-            alertCallback();
-          }
-        };
-  }
-
-  if (! navigator.notification.confirm) {
-    navigator.notification.confirm =
-        function (message, confirmCallback, title, buttonLabels){
-          var isConfirmed = window.confirm(message);
-          if (confirmCallback)
-          {
-            confirmCallback((isConfirmed) ? 1 : 2);
-          }
-        };
-  }
-}
-
 /* Function.bind polyfill */
 
 if (!Function.prototype.bind) {

--- a/www/cordova-polyfills.js
+++ b/www/cordova-polyfills.js
@@ -1,0 +1,34 @@
+if (! window.cordova) {
+
+  window.cordova = {bogus: "Cordova is absent, this stub is for polyfills."};
+
+  window.cordova['define'] = function(ident, thecode) {
+    var msg = "Cordova plugin '" + ident + "' ruthlessly skipped - no Cordova.";
+    window.console.log(msg);
+  };
+
+  if (! navigator.notification) {
+    navigator.notification = {};
+  }
+
+  if (! navigator.notification.alert) {
+    navigator.notification.alert =
+        function (message, alertCallback, title, buttonName) {
+          window.alert(message);
+          if (alertCallback) {
+            alertCallback();
+          }
+        };
+  }
+
+  if (! navigator.notification.confirm) {
+    navigator.notification.confirm =
+        function (message, confirmCallback, title, buttonLabels){
+          var isConfirmed = window.confirm(message);
+          if (confirmCallback)
+          {
+            confirmCallback((isConfirmed) ? 1 : 2);
+          }
+        };
+  }
+}

--- a/www/index.html
+++ b/www/index.html
@@ -150,6 +150,7 @@
     </script>
     <!-- Cordova -->
     <script src="cordova.js"></script>
+    <script src="cordova-polyfills.js"></script>
     <script src="FileViewerPlugin.js"></script>
     <!-- Components -->
     <script src="components/underscore/underscore.js"></script>


### PR DESCRIPTION
after the cordova.js load, so the polyfills are available as soon as
possible, when necessary.

Add a cordova polyfill for cordova.define, so we can blithely continue
without the plugins, in so far as the lack of their functionality allows.

(This enables us to continue without the FileViewerPlugin, for instance,
without any accommodation within the plugin, itself.)
