### PR TITLE
Fixes #52

### DIFF
--- a/plugins/FileViewerPlugin/src/android/FileViewerPlugin.java
+++ b/plugins/FileViewerPlugin/src/android/FileViewerPlugin.java
@@ -61,7 +61,15 @@ public class FileViewerPlugin extends Plugin {
         JSONObject obj = args.getJSONObject(0);
         MimeTypeMap mime = MimeTypeMap.getSingleton();
         Uri uri = obj.has("url") ? Uri.parse(obj.getString("url")) : null;
-        String ext=mime.getFileExtensionFromUrl(Uri.encode(uri.toString()));
+        // File file = new File(uri.getEncodedPath());
+        // Log.d(LOG_TAG, Uri.encode(uri.toString()));
+        // String ext=mime.getFileExtensionFromUrl(uri.toString());
+        String ext = "";
+        int x = uri.toString().lastIndexOf('.');
+        if (x > 0) {
+            ext = uri.toString().substring(x+1);
+        }
+        // Log.d(LOG_TAG, ext);
         String type = obj.has("type") ? obj.getString("type") : mime.getMimeTypeFromExtension(ext);
         
         JSONObject extras = obj.has("extras") ? obj.getJSONObject("extras") : null;


### PR DESCRIPTION
Turns out `MimeTypeMap.getFileExtensionFromUrl()` is a bit flakey as it can only handle certain chars. The implementation on the HTC was obviously even worse again.

Three cheers for native Android fragmentation
