### PR TITLE
Pin backbone to 0.9.10 to avoid a bug in testing harness that occurs with backbone 1.0.

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "SpiderOakMobile",
   "version": "0.1.0",
   "dependencies": {
-    "backbone": "latest",
+    "backbone": "~0.9.10",
     "underscore": "latest",
     "backbone.basicauth": "https://github.com/fiznool/backbone.basicauth.git",
     "backstack": "https://github.com/pwalczyszyn/backstack.git",


### PR DESCRIPTION
This pull request is to confirm that Travis build is fixed by the change.
