### PR TITLE
Public shares remove button

### DIFF
--- a/src/views/ShareRoomsViews.js
+++ b/src/views/ShareRoomsViews.js
@@ -288,6 +288,7 @@
     }
   });
 
+
   spiderOakApp.PublicShareRoomItemView = spiderOakApp.ShareRoomItemView.extend({
     events: {
       "tap .descend": "descend_tapHandler",


### PR DESCRIPTION
Add a simple remove button on public shares items.

This is reading for inclusion, but will require some subsequent tweaking:
- Use a real icon for the remove button
- Make the descend tap region encompass the rest of the list item, besides the remove button, and not just the item name.
