### PR TITLE
Change the paths to the back arrow and spideroak button so they appear.

### DIFF
--- a/www/css/themes/android.css
+++ b/www/css/themes/android.css
@@ -18,8 +18,8 @@ body {
 	position: absolute; 
 	left: 0;
 	padding: 0 3px;
-  background: url('../../img/ic_ab_back_holo_dark.png') no-repeat,
-    url('../../img/icon.png') no-repeat;
+  background: url('../img/ic_ab_back_holo_dark.png') no-repeat,
+    url('../img/icon.png') no-repeat;
 	width: 48px;
 	height:48px;
 	background-size: 16px, 35px;


### PR DESCRIPTION
@devgeeks: I am mystified why this change should suddenly be necessary.

I confirmed that the problem exists with a fresh clone, and don't know what
change caused the existing paths to become incorrect.
