### PR TITLE
Provide clear feedback on attempts to add public share rooms that are

### DIFF
--- a/src/collections/ShareRoomsCollections.js
+++ b/src/collections/ShareRoomsCollections.js
@@ -14,6 +14,9 @@
     initialize: function() {
       this.url = "https://" + spiderOakApp.config.server + "/share/";
     },
+    attrsToId: function (share_id, room_key) {
+      return spiderOakApp.b32nibbler.encode(share_id) + "/" + room_key + "/";
+    },
     which: "ShareRoomsCollection"
   });
   var ShareRoomsCollection = spiderOakApp.ShareRoomsCollection;
@@ -52,6 +55,26 @@
                   remember: remember});
       }.bind(this));
       // addHandler does the fetch for each model.
+    },
+    add: function (models, options) {
+      var it = this.get(this.attrsToId(models.share_id, models.room_key)),
+          changed;
+      if (it) {
+        if (it.get("remember") != models.remember) {
+          it.set("remember", models.remember);
+          changed = " (Remember " + (models.remember ?
+                                     "activated)" :
+                                     "deactivated)");
+        }
+        // @TODO: Use some kind of toast, or other non-modal alert.
+        navigator.notification.alert("Share Room " +
+                                     models.share_id + "/" +
+                                     models.room_key +
+                                     " already present" +
+                                     (changed ? changed : "") + ".");
+        return;
+      }
+      ShareRoomsCollection.prototype.add.call(this, models, options);
     },
     addHandler: function(model, collection, options) {
       var surroundingSuccess = options && options.success,


### PR DESCRIPTION
already being visited. Plus, indicate that the share room is already present, but adjust the
"remember" attribute if the re-add changes it.

Fixes #100.
