### PR TITLE
Move all user interaction - share room already present and share room not

### DIFF
--- a/src/collections/ShareRoomsCollections.js
+++ b/src/collections/ShareRoomsCollections.js
@@ -14,7 +14,10 @@
     initialize: function() {
       this.url = "https://" + spiderOakApp.config.server + "/share/";
     },
-    attrsToId: function (share_id, room_key) {
+    hasByAttributes: function(share_id, room_key) {
+      return this.get(this.attributesToId(share_id, room_key));
+    },
+    attributesToId: function (share_id, room_key) {
       return spiderOakApp.b32nibbler.encode(share_id) + "/" + room_key + "/";
     },
     which: "ShareRoomsCollection"
@@ -56,26 +59,6 @@
       }.bind(this));
       // addHandler does the fetch for each model.
     },
-    add: function (models, options) {
-      var it = this.get(this.attrsToId(models.share_id, models.room_key)),
-          changed;
-      if (it) {
-        if (it.get("remember") != models.remember) {
-          it.set("remember", models.remember);
-          changed = " (Remember " + (models.remember ?
-                                     "activated)" :
-                                     "deactivated)");
-        }
-        // @TODO: Use some kind of toast, or other non-modal alert.
-        navigator.notification.alert("Share Room " +
-                                     models.share_id + "/" +
-                                     models.room_key +
-                                     " already present" +
-                                     (changed ? changed : "") + ".");
-        return;
-      }
-      ShareRoomsCollection.prototype.add.call(this, models, options);
-    },
     addHandler: function(model, collection, options) {
       var surroundingSuccess = options && options.success,
           surroundingError = options && options.error;
@@ -90,11 +73,6 @@
           }
         }.bind(this),
         error: function(model, xhr, options) {
-          // @TODO: Use some kind of toast, or other non-modal alert.
-          navigator.notification.alert("Share Room " +
-                                       model.get("share_id") + "/" +
-                                       model.get("room_key") +
-                                      " not found.");
           this.remove(model);
           if (surroundingError) {
             surroundingError();

--- a/src/views/ShareRoomsViews.js
+++ b/src/views/ShareRoomsViews.js
@@ -278,13 +278,33 @@
       this.$("input").blur();
     },
     form_submitHandler: function(event) {
+      var remember = this.$("[name=remember]").is(":checked") ? 1 : 0,
+          shareId = this.$("[name=shareid]").val(),
+          roomKey = this.$("[name=roomkey]").val(),
+          pubShares = spiderOakApp.publicShareRoomsCollection;
+
       event.preventDefault();
       this.$("input").blur();
-      spiderOakApp.publicShareRoomsCollection.add({
-        remember: this.$("[name=remember]").is(":checked") ? 1 : 0,
-        share_id: this.$("[name=shareid]").val(),
-        room_key: this.$("[name=roomkey]").val()
-      });
+
+      if (pubShares.hasByAttributes(shareId, roomKey)) {
+        // @TODO: Use some kind of toast, or other non-modal alert.
+        navigator.notification.alert("Share Room <" +
+                                     shareId + "/" + roomKey +
+                                     "> already present");
+      }
+      else {
+        spiderOakApp.publicShareRoomsCollection.add({
+          remember: this.$("[name=remember]").is(":checked") ? 1 : 0,
+          share_id: this.$("[name=shareid]").val(),
+          room_key: this.$("[name=roomkey]").val()
+        }, {
+          error: function (model, xhr, options) {
+            navigator.notification.alert("Share Room <" +
+                                         shareId + "/" + roomKey +
+                                         "> not found");
+          }
+        });
+      }
       spiderOakApp.navigator.popView();
       // this.addAll();
     },


### PR DESCRIPTION
found - out of the share rooms collection and into the share rooms view.

The already-intricate provision for toggling share room remembering for
already present ones would get even more intricate, so just drop it.

This branch address part of issue #102. It still uses modal dialogs, but puts the use of them in the view rather than the collection.
