### PR TITLE
Implemented "Send Link" in long press pop up

### DIFF
--- a/src/views/FilesView.js
+++ b/src/views/FilesView.js
@@ -227,7 +227,6 @@
           spiderOakApp.dialogView.hide();
           var text = "I want to share this link to " + model.get("name") +
               " with you: " + "https://spideroak.com" + result;
-          console.log(text);
           var extras = {};
           extras[spiderOakApp.fileViewer.EXTRA_TEXT] = text;
           var params = {


### PR DESCRIPTION
Closes #63 and #65 

Compromised on always using the shorter copy … if it's an issue I could look at adding an "Email link" to the menu and using another plugin to pop up an email compose screen.
