### PR TITLE
Fixes #95

### DIFF
--- a/src/helpers/FileDownloadHelper.js
+++ b/src/helpers/FileDownloadHelper.js
@@ -74,7 +74,7 @@
                 errorCallback("File transfer aborted");
               });
               fileTransfer.download(
-                encodeURI(options.from),
+                options.from,
                 fileEntry.fullPath,
                 successCallback,
                 errorCallback,


### PR DESCRIPTION
Since switching from `model.urlResult() + model.get("name")` to `model.composedUrl()`, the url is encoded already and does not need to be encoded and doubly encoded :/
