### PR TITLE
Tests and poking around on the device both seem to work with the full 1.0

### DIFF
--- a/component.json
+++ b/component.json
@@ -7,7 +7,7 @@
     "backbone.basicauth": "https://github.com/fiznool/backbone.basicauth.git",
     "backstack": "https://github.com/pwalczyszyn/backstack.git",
     "Nibbler.min": "http://www.tumuski.com/library/Nibbler/Nibbler.js",
-    "zepto": "https://github.com/madrobby/zepto/archive/v1.0rc1.zip",
+    "zepto": "https://github.com/madrobby/zepto/archive/v1.0.zip",
     "iscroll": "latest",
     "moment": "~2.0.0",
     "store.js": "~1.3.6"


### PR DESCRIPTION
... Zepto release.  While this is unlikely to rectify the flaky bower download
problems, we're at least on a semantic version that gives us more latitude
to try various things to work around it.
