### PR TITLE
On unlocked password protected share rooms, add a "Forget password" action...

### DIFF
--- a/src/views/ShareRoomsViews.js
+++ b/src/views/ShareRoomsViews.js
@@ -561,7 +561,8 @@
         remove: function (event) {
           this.removePublicShare_tapHandler(event); },
         remember: function (event) { this.remember(); },
-        forget: function (event) { this.forget(); }
+        forget: function (event) { this.forget(); },
+        forgetPassword: function (event) { this.forgetPassword(); }
       }
     ),
     initialize: function() {
@@ -579,6 +580,10 @@
         actionItems = actionItems.concat({className: "remember",
                                           description: "Remember"});
       }
+      if (this.model.getPassword() && this.model.get("name")) {
+        actionItems = actionItems.concat({className: "forgetPassword",
+                                          description: "Forget password"});
+      }
       return spiderOakApp.ShareRoomItemView.prototype
           .a_longTapHandler.call(this, event, actionItems);
     },
@@ -587,6 +592,10 @@
     },
     forget: function(event) {
       this.model.set("remember", 0);
+    },
+    forgetPassword: function(event) {
+      this.model.removePassword();
+      this.model.fetch();
     },
     removePublicShare_tapHandler: function(event) {
       event.stopPropagation();

--- a/www/tpl/publicShareRoomItemViewTemplate.html
+++ b/www/tpl/publicShareRoomItemViewTemplate.html
@@ -9,7 +9,11 @@
     </div>
   <% } else { %>
     <div class="foldername">
-      <% if (name) { %> <%= name %>
+      <% if (name) { %>
+        <% if (password) { %>
+        <i class="icon-unlocked" style="color:#999;font-size:80%;"></i>
+        <% } %>
+      <%= name %>
       <% } else if (beenSituated) { %>
       <span title="Fetch failed, try later" style="color:#999"> &asymp; </span>
       <em><%= share_id %> / <%= room_key %></em>


### PR DESCRIPTION
... item, and include an unlocked icon on the list entries.

While this fixes #208, it's looking like the conveyance of credentials between accounts was due to something else - the only thing I can suppose is that I visited the share room via the SpiderOak web interface, and got a cookie that way.

Anyway, this adds a Forget Password action item, and visible indication that a share room is password protected when it is in the unlocked state, as well as when it is locked.
