### PR TITLE
fixes #222 and any other form fields

### DIFF
--- a/src/views/LoginView.js
+++ b/src/views/LoginView.js
@@ -45,7 +45,7 @@
 
       spiderOakApp.dialogView.showWait({subtitle:"Authenticating"});
 
-      var username = $("#unme").val();
+      var username = $("#unme").val().trim();
       var password = $("#pwrd").val();
       var rememberme = $("#rememberme").is(":checked");
 

--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -259,7 +259,7 @@
       spiderOakApp.dialogView.showWait({
         title: "Validating"
       });
-      var newServer = this.$("[name=server]").val(),
+      var newServer = this.$("[name=server]").val().trim(),
           wasServer = this.model.get("value");
       event.preventDefault();
       this.$("input").blur();

--- a/src/views/ShareRoomsViews.js
+++ b/src/views/ShareRoomsViews.js
@@ -300,8 +300,8 @@
     },
     form_submitHandler: function(event) {
       var remember = this.$("[name=remember]").is(":checked") ? 1 : 0,
-          shareId = this.$("[name=shareid]").val(),
-          roomKey = this.$("[name=roomkey]").val(),
+          shareId = this.$("[name=shareid]").val().trim(),
+          roomKey = this.$("[name=roomkey]").val().trim(),
           pubShares = spiderOakApp.publicShareRoomsCollection;
 
       event.preventDefault();


### PR DESCRIPTION
There should be no form fields that actually WANT a space… unless a password starts or ends with one.

So I am not trimming passwords, only share room ids and keys, usernames, etc.
