### PR TITLE
Make the entire Remember Me settings entry active, and have it trigger a

### DIFF
--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -37,13 +37,6 @@
         _.template(
           window.tpl.get("settingsViewTemplate"), this.settingsInfo
         ));
-      // Inhibit checkbox response to physical click - we go via the anchor:
-      spiderOakApp.rememberMeSettingInterlock =
-          this.rememberMeSettingInterlock.bind(this);
-      this.$el.find("#settings-rememberme").attr(
-        "onclick",
-        "return spiderOakApp.rememberMeSettingInterlock(true);"
-      );
       this.scroller = new window.iScroll(this.el, {
         bounce: !$.os.android,
         vScrollbar: !$.os.android,
@@ -81,25 +74,12 @@
         spiderOakApp.defaultEffect
       );
     },
-    rememberMeSettingInterlock: function(value) {
-      if (typeof value !== "undefined") {
-        this.settings_rememberme_tapped = value;
-      }
-      return this.settings_rememberme_tapped;
-    },
     rememberMeSetting_tapHandler: function(event) {
       event.preventDefault();
-      if (! this.rememberMeSettingInterlock()) {
-        $("#settings-rememberme").trigger('click');
-        this.rememberMeSettingInterlock(false);
-      }
-      else {
-        this.rememberMeSettingInterlock(false);
-      }
+      $("#settings-rememberme").trigger('click');
     },
     rememberMe_changeHandler: function(event) {
       event.preventDefault();
-      this.rememberMeSettingInterlock(false);
       var rememberme = $(event.target).is(":checked");
       var b32username = spiderOakApp.accountModel.get("b32username");
       if (rememberme) {

--- a/www/tpl/settingsViewTemplate.html
+++ b/www/tpl/settingsViewTemplate.html
@@ -15,7 +15,7 @@
     <li>
       <a class="remember-me">
         <span style="float:left;color:#666;">Remember me</span>
-        <div class="checkswitch">
+        <div style="z-index: -1" class="checkswitch">
           <input type="checkbox" id="settings-rememberme"
                  name="settings-rememberme"
           <%= (spiderOakApp.accountModel.get("rememberme")) ? "checked='true'" : "" %> />


### PR DESCRIPTION
click on the checkbox, to have the existing change handling code do its
job.

Fixes #229.

I have a small question regarding this change.

I'm adding an event.preventDefault() to both the new rememberMeSetting_tapHandler() and the already existing rememberMe_changeHandler().  I believe, however, that the latter will never be necessary, because the active encompassing anchor, together with the .preventDefault() in the .rememberMeSetting_tapHandler(), will only get the click via the .trigger('click') from the method associated with the anchor, never directly from the UI.  Should I leave out the second .preventDefault()?  Does it matter, one way or the other?
