### PR TITLE
Fixes #244

### DIFF
--- a/src/views/FavoritesView.js
+++ b/src/views/FavoritesView.js
@@ -10,6 +10,7 @@
       $           = window.$;
 
   spiderOakApp.FavoritesView = Backbone.View.extend({
+    destructionPolicy: "never",
     initialize: function() {
       _.bindAll(this);
       this.on("viewActivate",this.viewActivate);


### PR DESCRIPTION
Seems the FavoritesView was the only main level view to NOT have `destructionPolicy: "never"` set.
