### PR TITLE
Inhibit the tap-sensitivity for the encompassing Accounts settings,

### DIFF
--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -13,8 +13,8 @@
     destructionPolicy: "never",
     events: {
       "tap .send-feedback": "feedback_tapHandler",
-      //"tap .account-settings": "accountSettings_tapHandler",
-      "tap .server": "server_tapHandler",
+      "tap .account-settings": "accountSettings_tapHandler",
+      //"tap .server": "server_tapHandler",
       "change #settings-rememberme": "rememberMe_changeHandler"
     },
     initialize: function() {


### PR DESCRIPTION
settings Account "remember me" item, with minimum churn, while also
retaining the refinements, etc, for later implementation with a more
cooperative switch skin.

Fixes #274.
