### PR TITLE
Preserve and present what the user understands as their login name in the

### DIFF
--- a/src/models/AccountModel.js
+++ b/src/models/AccountModel.js
@@ -18,6 +18,7 @@
       storage_web_url: "",      // Irrelevant to mobile client for now.
 
       isLoggedIn: false,
+      loginname: "",
       b32username: "",
       basicAuthCredentials: "",
       login_url: "",
@@ -112,6 +113,11 @@
             _self.set("login_url_start", "https://" + server + "/browse/login");
             _self.set("logout_url_preface", "https://" + server + "/storage/");
 
+            // The name by which they logged in.  (For Blue/enterprise
+            // users, it's different than b32decode(b32username.)
+            _self.set("loginname", username);
+            // The base32 encrypted version of the internal username used
+            // on the login and content urls.
             _self.set("b32username",b32username);
             // @TODO: Set the keychain credentials
             // Set the basicauth details:

--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -163,7 +163,8 @@
       spiderOakApp.navigator.on("viewChanging",this.viewChanging);
     },
     getTemplateValues: function() {
-      return spiderOakApp.storageBarModel.toJSON();
+      return _.extend({loginname: spiderOakApp.accountModel.get("loginname")},
+                      spiderOakApp.storageBarModel.toJSON());
     },
     render: function() {
       this.$el.html(

--- a/tests/models/AccountModel.js
+++ b/tests/models/AccountModel.js
@@ -167,9 +167,7 @@ describe('AccountModel', function() {
     });
 
     describe('different login and content-URL username', function(){
-      it('(blue) login should succeed when login username differs by more' +
-         ' than case from content-URL base32 encoded username',
-         function() {
+      beforeEach(function() {
            this.blueLoginName = "test1@some.where.local";
            // spiderOakApp.b32nibbler.encode("some_test_user_123") ===>
            this.blueb32username = "ONXW2ZK7ORSXG5C7OVZWK4S7GEZDG";
@@ -188,10 +186,23 @@ describe('AccountModel', function() {
            this.accountModel.login(this.blueLoginName, this.password,
                                    this.successSpy, this.errorSpy);
            this.server.respond();
+      });
+      afterEach(function(){
+        Backbone.BasicAuth.set.restore();
+      });
+      it('Login to blue-style server should succeed - where login username' +
+         ' differs by more than case from content-URL base32 encoded username.',
+         function() {
            this.successSpy.should.have.been.calledOnce;
            this.errorSpy.should.not.have.been.called;
            Backbone.BasicAuth.set.should.have.been.called;
-           Backbone.BasicAuth.set.restore();
+         }
+        );
+      it('Blue-server login should yield accountModel "loginname" same' +
+         ' as that provided by user for login.',
+         function() {
+           this.accountModel.get("loginname").should.equal(
+             this.blueLoginName);
          }
         );
     });

--- a/www/tpl/settingsAccountViewTemplate.html
+++ b/www/tpl/settingsAccountViewTemplate.html
@@ -5,6 +5,17 @@
       <div class="info"><%= firstname + " " + lastname %></div>
       <div class="clearfix"></div>
     </li>
+    <% if (spiderOakApp.b32nibbler.decode(
+               spiderOakApp.accountModel.get("b32username")) !==
+            loginname) { %>
+    <li>
+      <div class="label">Login name</div>
+      <div class="info">
+        <%= loginname %>
+      </div>
+      <div class="clearfix"></div>
+    </li>
+      <% } %>
     <li>
       <div class="label">Username</div>
       <div class="info">


### PR DESCRIPTION
... settings Account info screen.  If the username is different than the login
name, present both.  Otherwise, just present the username.

(It may be unnecessary, from the user's point of view, to present both.
I'm not acquainted with use of blue/enterprise accounts, so don't know
whether or not the username is a totally internal detail, and/or whether it
would be useful debugging info, so I'm erring on the side of completeness.)

Fixes #276.
