### PR TITLE
Substitute "public" for "visited" in object names, where the name is

### DIFF
--- a/src/collections/ShareRoomsCollections.js
+++ b/src/collections/ShareRoomsCollections.js
@@ -1,5 +1,5 @@
 /**
- * visitedShareRoomsCollection.js
+ * ShareRoomsCollection.js
  */
 (function (spiderOakApp, window, undefined) {
   "use strict";

--- a/src/views/ShareRoomsViews.js
+++ b/src/views/ShareRoomsViews.js
@@ -9,7 +9,7 @@
       _           = window._,
       $           = window.$;
 
-  /** A model-less view of the visited share rooms and account share rooms.
+  /** A model-less view of the public share rooms and account share rooms.
    *
    */
   spiderOakApp.ShareRoomsRootView = Backbone.View.extend({
@@ -35,24 +35,24 @@
         hScrollbar: false
       });
 
-      // Load the visited and account share rooms simultaneously (quasi-async)
+      // Load the public and "my" share rooms simultaneously (quasi-async)
       window.setTimeout(function(){
         this.loadMyShareRooms();
       }.bind(this), 10);
-      this.loadVisitedShareRooms();
+      this.loadPublicShareRooms();
 
       return this;
     },
-    loadVisitedShareRooms: function() {
-      this.visitedShareRoomsListView =
-        new spiderOakApp.VisitedShareRoomsListView({
+    loadPublicShareRooms: function() {
+      this.publicShareRoomsListView =
+        new spiderOakApp.PublicShareRoomsListView({
           collection: spiderOakApp.publicShareRoomsCollection,
-          el: this.$(".visitedShareRoomsSection"),
+          el: this.$(".publicShareRoomsSection"),
           scroller: this.scroller
         });
       // When we've finished fetching the folders, help hide the spinner:
-      this.visitedShareRoomsListView.$el.one("complete", function(event) {
-        this.visitedShareRoomsListView.settle();
+      this.publicShareRoomsListView.$el.one("complete", function(event) {
+        this.publicShareRoomsListView.settle();
         window.setTimeout(function(){
           this.scroller.refresh();
         }.bind(this),0);
@@ -129,7 +129,7 @@
     close: function() {
       // Clean up our subviews
       this.scroller.destroy();
-      this.visitedShareRoomsListView.close();
+      this.publicShareRoomsListView.close();
       this.myShareRoomsListView.close();
     },
     which: "ShareRoomsRootView"
@@ -189,7 +189,7 @@
     which: "MyShareRoomsListView"
   });
 
-  spiderOakApp.VisitedShareRoomsListView = Backbone.View.extend({
+  spiderOakApp.PublicShareRoomsListView = Backbone.View.extend({
     initialize: function() {
       this.subViews = [];
       if (this.options.scroller) {
@@ -197,7 +197,7 @@
       }
 
       /** A handle on our section's content list. */
-      this.$elList = this.$el.find(".visitedShareRoomsList");
+      this.$elList = this.$el.find(".publicShareRoomsList");
 
       _.bindAll(this);
       this.collection.on( "add", this.addOne, this );
@@ -217,8 +217,8 @@
       return this;
     },
     settle: function() {
-      this.$el.find(".visitedSharesViewLoading")
-          .removeClass("loadingVisitedShares");
+      this.$el.find(".publicSharesViewLoading")
+          .removeClass("loadingPublicShares");
     },
     addOne: function(model) {
       var view = new spiderOakApp.PublicShareRoomItemView({
@@ -251,7 +251,7 @@
         }
       });
     },
-    which: "VisitedShareRoomsListView"
+    which: "PublicShareRoomsListView"
   });
 
   spiderOakApp.AddShareRoomView = Backbone.View.extend({

--- a/tpl/shareRoomsRootViewTemplate.html
+++ b/tpl/shareRoomsRootViewTemplate.html
@@ -8,14 +8,14 @@
       <li class="sep">Loading...</li>
     </ul>
   </div>
-  <div class="visitedShareRoomsSection">
+  <div class="publicShareRoomsSection">
     <ul>
       <li class="sep" style="white-space: nowrap">Public Shares</li>
     </ul>
-    <ul class="visitedSharesViewLoading loadingVisitedShares">
+    <ul class="publicSharesViewLoading loadingPublicShares">
     </ul>
-    <ul class="visitedShareRoomsList"></ul>
-    <ul class="visitedSharesViewLoading loadingVisitedShares">
+    <ul class="publicShareRoomsList"></ul>
+    <ul class="publicSharesViewLoading loadingPublicShares">
       <li class="sep">Loading...</li>
     </ul>
   </div>

--- a/www/css/app.css
+++ b/www/css/app.css
@@ -225,7 +225,7 @@ ul li.sep {
 .folderViewLoading .sep,
 .mySharesViewLoading .sep,
 .versionsViewLoading .sep,
-.visitedSharesViewLoading .sep {
+.publicSharesViewLoading .sep {
   background-color: #ccc;
   color: #000;
 }
@@ -309,7 +309,7 @@ ul.rounded li:first-child {
 .folderViewLoading,
 .mySharesViewLoading,
 .versionsViewLoading,
-.visitedSharesViewLoading {
+.publicSharesViewLoading {
   display: none;
 }
 
@@ -317,7 +317,7 @@ ul.rounded li:first-child {
 .folderViewLoading.loadingFiles,
 .versionsViewLoading.loadingVersions,
 .mySharesViewLoading.loadingMyShares,
-.visitedSharesViewLoading.loadingVisitedShares {
+.publicSharesViewLoading.loadingPublicShares {
   display: block;
 }
 


### PR DESCRIPTION
referring to a public share room (as opposed to a share room that is
currently being visited by the app).

I've tested manually, and noticed on my devices when trying to view, eg images, that I'm getting the "Cannot find an app to view files of this type..." error - but that happens with my ad hoc builds from the master, without these changes, as well.   Do test with a proper build, though, to make sure nothing is disrupted.

Fixes #190.
