### PR TITLE
Added compilation of templates in ./custom/brand/tpl/**/*.html

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -286,7 +286,7 @@ module.exports = function(grunt) {
           variable  : 'tmpl',
           requirejs : false
         },
-        src  : ['tpl/**/*.html'],
+        src  : ['tpl/**/*.html', 'custom/brand/tpl/**/*.html'],
         dest : 'www/js/SpiderOak-templates.js'
       }
     }

--- a/src/views/AboutView.js
+++ b/src/views/AboutView.js
@@ -46,8 +46,9 @@
             this.settings.platform + " app version " + spiderOakApp.version;
       var extras = {};
       extras[spiderOakApp.fileViewer.EXTRA_SUBJECT] = subject;
-      extras[spiderOakApp.fileViewer.EXTRA_EMAIL] = this.settings.platform +
-        "@spideroak.com";
+      extras[spiderOakApp.fileViewer.EXTRA_EMAIL] =
+        window.spiderOakApp.settings.getValue("contactEmail") ||
+        this.settings.platform + "@spideroak.com";
       var params = {
         action: spiderOakApp.fileViewer.ACTION_SEND,
         type: "text/plain",

--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -55,6 +55,7 @@
       var extras = {};
       extras[spiderOakApp.fileViewer.EXTRA_SUBJECT] = subject;
       extras[spiderOakApp.fileViewer.EXTRA_EMAIL] =
+        window.spiderOakApp.settings.getValue("contactEmail") ||
         platform + "@" + s("spideroak.com");
       var params = {
         action: spiderOakApp.fileViewer.ACTION_SEND,

--- a/tpl/aboutSpiderOakViewTemplate.html
+++ b/tpl/aboutSpiderOakViewTemplate.html
@@ -8,7 +8,7 @@
   <div class="about-spideroak-content">
     <p>The {{= s("SpiderOak") }} {{= it.platform }} application provides an easy way to access your data on the move, open ShareRooms, view historical versions, and quickly email files to friends, colleagues, and/or clients.</p>
     <p>However - you don’t have to be a {{= s("SpiderOak") }} user to enjoy the benefits of our {{= it.platform }} application. You can open the ShareRoom of a friend or colleague by entering their ShareID and a valid RoomKey. You can also email files through a secure link.</p>
-    <p>If you would like to learn more about {{= s("SpiderOak") }}, please visit <a href="#spideroak" data-url="https://spideroak.com" class="site-link">https://spideroak.com</a> and download the {{= s("SpiderOak")}} client to get started with your FREE 2 GB account.</p>
+    <p>If you would like to learn more about {{= s("SpiderOak") }}, please visit <a href="#spideroak" data-url="https:\/\/{{= s('spideroak.com') }}" class="site-link" style="white-space: nowrap;">https:\/\/{{= s('spideroak.com') }}</a> and download the {{= s("SpiderOak")}} client to get started with your FREE 2 GB account.</p>
     <p>Thank you for using {{= s("SpiderOak") }} and please don’t hesitate to send comments or questions to <a href="#email-feedback" class="email-link">{{= it.platform }}@{{= s("spideroak.com") }}</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
This allows templates compiled from there to overwrite templates compiled from ./tpl/*_/_.html

Also found and corrected contact email branding and an issue that had caused some parts of the about view to not show even on the mail released app.
