### PR TITLE
Move the logout button to the settings menu.

### DIFF
--- a/src/views/MenuSheetView.js
+++ b/src/views/MenuSheetView.js
@@ -13,7 +13,7 @@
   spiderOakApp.MenuSheetView = Backbone.View.extend({
     el: "#menusheet",
     events: {
-      "tap .logout": "logout_tapHandler",
+      "tap .logout": "login_tapHandler",
       "tap .recents": "recents_tapHandler",
       "tap .favorites": "favorites_tapHandler",
       "tap .sharerooms": "sharerooms_tapHandler",
@@ -32,9 +32,7 @@
       $(document).on("online", this.online);
     },
     render: function(refresh) {
-      var inOrOut = {"inorout":
-                     spiderOakApp.accountModel.get("isLoggedIn") ?"Out" :"In"};
-      this.$el.html(window.tmpl["menusheetTemplate"](inOrOut));
+      this.$el.html(window.tmpl["menusheetTemplate"]());
       this.$("input[type=search]").attr("disabled",true);
       // Add subviews for menu items
       if (spiderOakApp.accountModel.get("isLoggedIn")) {
@@ -265,30 +263,11 @@
         );
       }
     },
-    logout_tapHandler: function(event) {
-      if (spiderOakApp.accountModel.get("isLoggedIn")) {
-        window.setTimeout(function(){
-          navigator.notification.confirm(
-            'Are you sure you want to sign out?',
-            function (button) {
-              if (button !== 1) {
-                return;
-              }
-              spiderOakApp.accountModel.logout();
-              $("#subviews").html(
-                "<ul class=\"folderViewLoading loadingFolders loadingFiles\">" +
-                "<li class=\"sep\">Loading...</li></ul>");
-            }.bind(spiderOakApp),
-            'Sign out'
-          );
-        }.bind(this),50);
-      }
-      else {
-        $("#subviews").html(
-          "<ul class=\"folderViewLoading loadingFolders loadingFiles\">" +
+    login_tapHandler: function(event) {
+      $("#subviews").html(
+        "<ul class=\"folderViewLoading loadingFolders loadingFiles\">" +
           "<li class=\"sep\">Loading...</li></ul>");
-        $(document).trigger("logoutSuccess");
-      }
+      $(document).trigger("logoutSuccess");
     },
     offline: function() {
       this.$(".hive").hide();

--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -16,6 +16,7 @@
       "tap .send-feedback": "feedback_tapHandler",
       "tap .account-settings": "accountSettings_tapHandler",
       "tap .server": "server_tapHandler",
+      "tap .logout": "logout_tapHandler",
       "change #settings-rememberme": "rememberMe_changeHandler"
     },
     initialize: function() {
@@ -23,6 +24,7 @@
       this.on("viewActivate", this.viewActivate);
       this.on("viewDeactivate", this.viewDeactivate);
       $(document).on("settingChanged", this.render);
+      $(document).on("logoutSuccess", this.render);
       spiderOakApp.navigator.on("viewChanging", this.viewChanging);
     },
     render: function() {
@@ -117,6 +119,31 @@
         {},
         spiderOakApp.defaultEffect
       );
+    },
+    logout_tapHandler: function(event) {
+      if (spiderOakApp.accountModel.get("isLoggedIn")) {
+        window.setTimeout(function(){
+          navigator.notification.confirm(
+            'Are you sure you want to sign out?',
+            function (button) {
+              if (button !== 1) {
+                return;
+              }
+              spiderOakApp.accountModel.logout();
+              $("#subviews").html(
+                "<ul class=\"folderViewLoading loadingFolders loadingFiles\">" +
+                "<li class=\"sep\">Loading...</li></ul>");
+            }.bind(spiderOakApp),
+            'Sign out'
+          );
+        }.bind(this),50);
+      }
+      else {
+        $("#subviews").html(
+          "<ul class=\"folderViewLoading loadingFolders loadingFiles\">" +
+          "<li class=\"sep\">Loading...</li></ul>");
+        $(document).trigger("logoutSuccess");
+      }
     },
     viewChanging: function(event) {
       if (!event.toView || event.toView === this) {

--- a/tpl/menusheetTemplate.html
+++ b/tpl/menusheetTemplate.html
@@ -14,8 +14,12 @@
     <li><a class="recents"><i class="icon-clock"></i> Recents</a></li>
     <li><a class="settings"><i class="icon-cog"></i> Settings</a></li>
     <li class="sep"></li>
-    <li><a class="about"><i class="icon-info"></i> About {{= s("SpiderOak") }}</a></li>
-    <li><a class="logout"><i class="icon-exit"></i>
-        Log {{=it.inorout}}</a></li>
+    <li><a class="about">
+        <i class="icon-info"></i> About {{= s("SpiderOak") }}</a>
+    </li>
+    {{? ! spiderOakApp.settings.getValue("inhibitAdvancedLogin") &&
+        ! spiderOakApp.accountModel.get("isLoggedIn")}}
+    <li><a class="logout"><i class="icon-exit"></i>Log In</a></li>
+    {{?}}
   </ul>
 </div>

--- a/tpl/settingsViewTemplate.html
+++ b/tpl/settingsViewTemplate.html
@@ -15,13 +15,22 @@
     <li style="padding: 15px 10px 25px 10px;">
       <span style="float:left;color:#666;">Remember me</span>
       <div class="checkswitch">
-        <input type="checkbox" id="settings-rememberme" name="settings-rememberme"
+        <input type="checkbox"
+               id="settings-rememberme"
+               name="settings-rememberme"
           {{?spiderOakApp.accountModel.get("rememberme")}}checked='true'{{?}} />
         <label for="settings-rememberme">
           <span data-off="No" data-on="Yes"></span>
         </label>
       </div>
       <div class="clearfix"></div>
+    </li>
+  </ul>
+  <ul>
+    <li><a class="logout">Log Out</a></li>
+    <li class="logout-warning">
+      Logging out while <strong>Remember Me</strong> is active will clear
+      your data from this device.
     </li>
   </ul>
   {{?}}


### PR DESCRIPTION
Notes:
- I'm keeping the login button on the menu sheet.
- Hitting the resituated logout button still takes you to the login form.
- I failed to find the source of logout css class special behavior, so
  didn't change the now misnamed "logout" class on the menu sheet to
  login.  That should be rectified.
- I included the settings-residing logout button in the section with the
  account name, in contrast to where it is in the native iOS version.

Fixes #338, given some tailoring.
