### PR TITLE
Require that 403 response for faux login attempt includes X-SpiderOak-API header.

### DIFF
--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -326,7 +326,10 @@
 
           // We use xhr.status because xhr is a consistent parameter for both
           // success and failure callbacks:
-          if (xhr.status !== 403) {
+          if ((xhr.status !== 403) ||
+              // Proper SpiderOak servers include X-SpiderOak-API header
+              // on 403 responses:
+              (! xhr.getResponseHeader("X-SpiderOak-API"))) {
             // Host is not a SpiderOak service provider - fail:
             spiderOakApp.dialogView.hide();
             if (spiderOakApp.navigator.viewsStack.length > 0) {


### PR DESCRIPTION
Fixes #326.

This verifies, only during the course of attempting a bogus login to validate an server address chnage, that the server is passing the spideroak-API-specific 'X-SpiderOak-API' header in the 403 response.

This needs to also be merged to the master-ios-integration-branch.
