### PR TITLE
Modified grunt debug task to accept a test param

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -306,8 +306,9 @@ module.exports = function(grunt) {
   grunt.registerTask('min', ['uglify']); // polyfil
 
   // Build tasks
-  grunt.registerTask('debug','Create a debug build', function(platform) {
-    grunt.task.run('jshint', 'dot', 'concat', 'shell:mochadot');
+  grunt.registerTask('debug','Create a debug build', function(platform, test) {
+    test = test || 'dot';
+    grunt.task.run('jshint', 'dot', 'concat', 'shell:mocha'+test);
     grunt.task.run('shell:debug_' + platform);
   });
   grunt.registerTask('beta','Create a beta build', function(platform) {


### PR DESCRIPTION
- `grunt debug:android` will run `mochadot` (as before... default)
- `grunt debug:android:min` will run `mochamin`
- ``grunt debug:android:spec` will run `mochaspec`
