### PR TITLE
Adds image previews (thumbnails) to FileLists where previews are available

### DIFF
--- a/src/views/FilesView.js
+++ b/src/views/FilesView.js
@@ -667,17 +667,47 @@
       this.model.on("change",this.render);
     },
     render: function() {
+      var model = this.model;
       // if (window.Modernizr.overflowscrolling) {
         this.$el.html(
-          window.tmpl["fileItemViewTemplate"](this.model.toJSON())
+          window.tmpl["fileItemViewTemplate"](model.toJSON())
         );
       // }
       // else {
       //   this.$el.html(
-      //     window.tmpl["fileItemViewMinTemplate"](this.model.toJSON())
+      //     window.tmpl["fileItemViewMinTemplate"](model.toJSON())
       //   );
       // }
-      this.$("a").data("model",this.model);
+      this.$("a").data("model",model);
+      // Previews
+      var $icon = this.$(".icon");
+      if (model.get("preview_48")) {
+        var downloadOptions = {
+          fileName: "thumb_" + model.get("name"),
+          from: model.composedUrl(true) + "?preview_48",
+          to: ".caches",
+          fsType: window.LocalFileSystem.TEMPORARY,
+          headers: {
+            "Authorization": (
+              model.getBasicAuth() ||
+                  spiderOakApp.accountModel.get("basicAuthCredentials"))
+          }
+        };
+        spiderOakApp.downloader.downloadFile(
+          downloadOptions,
+          function(fileEntry) {
+            fileEntry.file(function(file){
+              if (file.size > 0) {
+                $icon.html("<img src='"+fileEntry.toURL()+"' style='width:100%;position:absolute;top:0;left:0;' /><div style='clear:both'></div>");
+                $icon.css("background","none");
+              }
+            },function(){});
+          },
+          function(err) {
+            // well, that's cool... do nothing then.
+          }
+        );
+      }
       return this;
     },
     a_tapHandler: function(event) {


### PR DESCRIPTION
Fixes #291 

It uses FileTransfer to download the preview_48 (has to, since it needs authentication... and CS would need cert auth).

If there _is_ a preview, the file icon is removed and an image added in the left-hand div.

It's surprising how few images actually have previews :(

Three results could mean no preview:
1. there is no preview_48 attribute in the JSON model
2. there _is_, but for some reason the file when downloaded is 0 bytes
3. the FileTransfer errors out for some reason

In any of these cases, it just leaves the file icon alone.
