### PR TITLE
issue 404 - strange input form

### DIFF
--- a/www/res/config/AndroidManifest.xml
+++ b/www/res/config/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application android:debuggable="true" android:hardwareAccelerated="true" android:icon="@drawable/icon" android:label="@string/app_name">
-        <activity android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale" android:label="@string/app_name" android:name="SpiderOak" android:theme="@android:style/Theme.Black.NoTitleBar">
+        <activity android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale" android:label="@string/app_name" android:name="SpiderOak" android:theme="@android:style/Theme.Black.NoTitleBar" android:windowSoftInputMode="adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
At heart this is due to the keyboard coming up and fooling the view into thinking it's in landscape setting off the landscape media query in the css.

Seems that Cordova puts the android:windowSoftInputMode in the <manifest> tag instead of the <activity> tag so even though we had set it to "adjustPan" the default of "adjustResize" was being used instead.

So.. I moved it to <activity> and it fixes the problem.

BUT... it means we need to keep our eyes open for places where this messes stuff up instead of fixing it.
