### PR TITLE
issue 378 - max passcode retries

### DIFF
--- a/src/views/LoginView.js
+++ b/src/views/LoginView.js
@@ -259,6 +259,8 @@
     initialize: function() {
       window.bindMine(this);
       this.action = "auth";
+      this.incorrectAttempts = 0;
+      this.maxIncorrectAttempts = 5;
     },
     render: function() {
       var title = "Enter your 4 digit passcode to unlock";
@@ -315,10 +317,20 @@
         if (spiderOakApp.settings.getValue("passcode") === passcode) {
           this.dismiss();
         } else {
+          this.incorrectAttempts++;
+          var tooMany = (this.incorrectAttempts >= this.maxIncorrectAttempts);
           spiderOakApp.dialogView.showNotify({
             title: "Error",
-            subtitle: "Passcode incorrect. <br>Try again."
+            subtitle: "Passcode incorrect." +
+              ((tooMany) ? "<br>Too many attempts." : "<br>Try again.") +
+              "<br><br>attempt " + this.incorrectAttempts + " of " +
+              this.maxIncorrectAttempts
           });
+          if (tooMany) {
+            spiderOakApp.accountModel.bypassPasscode();
+            spiderOakApp.accountModel.logout();
+            this.dismiss();
+          }
           // Clear the confirm code so they can try again
           $passcodeInput.val("");
         }

--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -461,6 +461,8 @@
       this.on("viewDeactivate",this.viewDeactivate);
       spiderOakApp.navigator.on("viewChanging",this.viewChanging);
       this.action = this.options.action || "set";
+      this.incorrectAttempts = 0;
+      this.maxIncorrectAttempts = 5;
     },
     render: function() {
       var title = "Enter a new 4 digit passcode";
@@ -554,10 +556,20 @@
               );
             }
           } else {
+            this.incorrectAttempts++;
+            var tooMany = (this.incorrectAttempts >= this.maxIncorrectAttempts);
             spiderOakApp.dialogView.showNotify({
               title: "Error",
-              subtitle: "Passcode incorrect. <br>Try again."
+              subtitle: "Passcode incorrect." +
+                ((tooMany) ? "<br>Too many attempts." : "<br>Try again.") +
+                "<br><br>attempt " + this.incorrectAttempts + " of " +
+                this.maxIncorrectAttempts
             });
+            if (tooMany) {
+              spiderOakApp.accountModel.bypassPasscode();
+              spiderOakApp.accountModel.logout();
+              this.dismiss();
+            }
             // Clear the confirm code so they can try again
             $passcodeInput.val("");
           }


### PR DESCRIPTION
Passcode auth entry (both to get into the app and to get to the passcode settings) now have a maximum retries of 5.

There are plenty of ways to game the system, but it's a lot better than the current total lack of a limit.
