### PR TITLE
Issue 412 - passcode timeout regression

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -206,15 +206,12 @@
         spiderOakApp.accountModel.basicAuthManager
           .setAccountBasicAuth(credentials[0], credentials[1]);
         spiderOakApp.onLoginSuccess();
-        var passcode = spiderOakApp.settings.getOrDefault("passcode",
-                                                          undefined);
+        var passcode = spiderOakApp.accountModel.getPasscode();
         if (passcode) {
           if (! spiderOakApp.accountModel.getLoginState) {
             // This shouldn't happen:
             console.log("Unexpected application state: passcode " +
                         "set without active login - removing it.");
-            // No passcode operation while not logged in
-            spiderOakApp.settings.remove("passcode");
           }
           else {
             this.passcodeAuthEntryView =
@@ -287,16 +284,14 @@
       // This isn't quick enough on iOS as it saves a shot of what was on the
       //    screen when pausing and uses that as a splash screen of sorts.
       //    We might need to use the splash screen plugin...
-      var passcode = spiderOakApp.settings.getOrDefault("passcode", undefined);
+      var passcode = spiderOakApp.accountModel.getPasscode();
       if (passcode && ! spiderOakApp.accountModel.getLoginState()) {
         console.log("Unexpected application state: passcode " +
-                    "set without active login - removing it.");
-        spiderOakApp.settings.remove("passcode");
+                    "set without active login.");
         return;
       }
 
-      var passcodeTimeout =
-            spiderOakApp.settings.getOrDefault("passcodeTimeout", 0);
+      var passcodeTimeout = spiderOakApp.accountModel.getPasscodeTimeout();
       var timeoutInMinutes =
         Math.floor(((Date.now() - spiderOakApp.lastPaused) / 1000) / 60);
       if (passcode && (timeoutInMinutes >= passcodeTimeout)) {

--- a/src/models/AccountModel.js
+++ b/src/models/AccountModel.js
@@ -68,10 +68,6 @@
     },
     loggedIn: function() {
       this.setLoginState(true);
-      // Establish passcode stuff:
-      if (this.getPasscode()) {
-        this.activatePasscode();
-      }
       if (this.passcodeWasBypassed()) {
         this.passcodeWasBypassedFollowup();
       }
@@ -129,7 +125,6 @@
         true
       );
       spiderOakApp.settings.saveRetainedSettings();
-      this.activatePasscode();
     },
     /** Return passcode timeout associated with account, or 0 if none. */
     getPasscodeTimeout: function () {
@@ -149,37 +144,14 @@
         true
       );
       spiderOakApp.settings.saveRetainedSettings();
-      this.activatePasscode();
     },
     /** Remove this account's passcode, and deactivate it. */
     unsetPasscode: function () {
       // Do this whether or not an account login currently is active.
-      this.deactivatePasscode();
       spiderOakApp.settings.remove(this.getPasscodeSettingId("passcode"));
       spiderOakApp.settings.remove(
         this.getPasscodeSettingId("passcodeTimeout")
       );
-      spiderOakApp.settings.saveRetainedSettings();
-    },
-    /** Activate the account's associated passcode for the current session. */
-    activatePasscode: function () {
-      if (! this.getLoginState()) {
-        return false;
-      }
-      spiderOakApp.settings.setOrCreate("passcode",
-                                        this.getPasscode(),
-                                        false);
-      spiderOakApp.settings.setOrCreate("passcodeTimeout",
-                                        this.getPasscodeTimeout(),
-                                        false);
-    },
-    /** Deactivate the current session's passcode. */
-    deactivatePasscode: function () {
-      if (! this.getLoginState()) {
-        return false;
-      }
-      spiderOakApp.settings.remove("passcode");
-      spiderOakApp.settings.remove("passcodeTimeout");
       spiderOakApp.settings.saveRetainedSettings();
     },
     /** Bypass the passcode, prepping for followup on next login. */
@@ -420,8 +392,6 @@
     logout: function(successCallback) {
       // Clear basic auth details:
       this.basicAuthManager.clear();
-      // ... and other app state associated with the account:
-      this.deactivatePasscode();
       spiderOakApp.settings.remove("rememberedAccount");
       spiderOakApp.settings.saveRetainedSettings();
       if (this.getLoginState() === true) {

--- a/src/views/LoginView.js
+++ b/src/views/LoginView.js
@@ -314,7 +314,7 @@
       } else if (passcode.length === 3) {
         $passcodeInput.val(passcode.toString()+num);
         passcode = $passcodeInput.val();
-        if (spiderOakApp.settings.getValue("passcode") === passcode) {
+        if (spiderOakApp.accountModel.getPasscode() === passcode) {
           this.dismiss();
         } else {
           this.incorrectAttempts++;

--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -527,7 +527,7 @@
           }
         } else { // action === auth
           // Push to the passcode options screen
-          if (spiderOakApp.settings.getValue("passcode") === passcode) {
+          if (spiderOakApp.accountModel.getPasscode() === passcode) {
             if (spiderOakApp.navigator.viewsStack[
                   spiderOakApp.navigator.viewsStack.length - 2
                 ].instance

--- a/tests/models/AccountModel.js
+++ b/tests/models/AccountModel.js
@@ -126,31 +126,24 @@ describe('AccountModel', function() {
         delete this.accountPasscodeTimeout;
         delete this.settings;
       });
-      it('Should set app passcode when account passcode is set', function () {
-        this.accountPasscode.should.equal(
-          this.settings.getOrDefault("passcode", "xxxx"));
+      it('Should properly set passcode', function () {
+        this.accountModel.getPasscode().should.be(this.accountPasscode);
       });
-      it('Should set app passcodeTimeout when account one is set', function () {
-        this.accountModel.setPasscodeTimeout(this.accountPasscodeTimeout);
-        this.accountPasscodeTimeout.should.equal(
-          this.settings.getOrDefault("passcodeTimeout", "xxxx"));
+      it('Should properly set passcodeTimeout', function () {
+        this.accountModel.getPasscodeTimeout().should.be(
+          this.accountPasscodeTimeout);
       });
-      it('should unset app passcode when account passcode is unset',
+      it('should properly unset app passcode',
          function () {
-           chai.expect(this.settings.getOrDefault("passcode")).to.equal(
-             this.accountPasscode);
            this.accountModel.unsetPasscode();
-           chai.expect(this.settings.getOrDefault("passcode")).to.not.exist;
-           chai.expect(this.settings.getOrDefault("passcodeTimeout"))
-             .to.not.exist;
+           chai.expect(this.accountModel.getPasscode()).to.be.undefined;
+           chai.expect(this.accountModel.getPasscodeTimeout()).to.equal(0);
          });
-      it('should unset app passcode on logout from account having passcode',
+      it('should unset passcode on logout',
          function () {
-           chai.expect(this.settings.getOrDefault("passcode")).to.equal(
-             this.accountPasscode);
            this.accountModel.logout();
            this.server.respond();
-           chai.expect(this.settings.getOrDefault("passcode")).to.not.exist;
+           chai.expect(this.accountModel.getPasscode()).to.be.undefined;
          });
       describe('logout and back in', function () {
         beforeEach(function () {
@@ -159,29 +152,16 @@ describe('AccountModel', function() {
           this.accountModel.login(this.username, this.password,
                                   this.successSpy, this.errorSpy);
           this.server.respond();
-        });          
+        });
         it('should set account passcode and timeout' +
            ' on re-login to passcoded account',
            function () {
-             this.accountPasscode.should.equal(
-               this.accountModel.getPasscode()
-             );
-             this.accountPasscodeTimeout.should.equal(
-                 this.accountModel.getPasscodeTimeout()
-             );
-           });
-        it('should set active passcode and timeout' +
-           ' on re-login to passcoded account',
-           function () {
-             this.accountPasscode.should.equal(
-               this.settings.getOrDefault("passcode", "xxxx")
-             );
-             this.accountPasscodeTimeout.should.equal(
-               this.settings.getOrDefault("passcodeTimeout", "xxxx")
-             );
+             this.accountModel.getPasscode().should.be(this.accountPasscode);
+             this.accountModel.getPasscodeTimeout().should.be(
+               this.accountPasscodeTimeout);
            });
       });
-      describe('bypass passcode then logout and back in', function () {
+      describe('bypass passcode', function () {
         beforeEach(function () {
           this.accountModel.bypassPasscode();
           this.accountModel.logout();
@@ -196,7 +176,7 @@ describe('AccountModel', function() {
         afterEach(function () {
           this.followupStub.restore();
         });
-        it('should register that passcode was bypassed in account',
+        it('should register that passcode was bypassed',
            function () {
              this.accountModel.passcodeWasBypassed().should.be.true;
            });


### PR DESCRIPTION
Some old stuff remained after the upgrade to per-user passcodes

Cleared out remaining refs to settings.getOrDefault("passcode") or settings.getOrDefault("passcodeTimeout")

Replaced with accountModel.getPasscode() and accountModel.getPasscodeTimeout()
