### PR TITLE
Reenable desktop browser operation, after file preview.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -469,9 +469,6 @@
                                                        successCallback,
                                                        errorCallback) {
         console.log("fake downloadFile");
-        spiderOakApp.dialogView.showWait({
-          title: "Debugging mode: Contents not dowloaded"
-        });
         var dummyFileEntry = {fullPath: "/sdcard" + downloadOptions.to,
                               name: downloadOptions.fileName};
         return successCallback(dummyFileEntry);

--- a/src/views/FilesView.js
+++ b/src/views/FilesView.js
@@ -696,12 +696,19 @@
         spiderOakApp.downloader.downloadFile(
           downloadOptions,
           function(fileEntry) {
-            fileEntry.file(function(file){
-              if (file.size > 0) {
-                $icon.html("<img src='"+fileEntry.toURL()+"' style='width:100%;position:absolute;top:0;left:0;' /><div style='clear:both'></div>");
-                $icon.css("background","none");
-              }
-            },function(){});
+            if (fileEntry.file) {
+              fileEntry.file(function(file){
+                if (file.size > 0) {
+                  $icon.html("<img src='"+fileEntry.toURL()+"' style='" +
+                             "width:100%;position:absolute;top:0;left:0;'"+
+                             "/><div style='clear:both'></div>");
+                  $icon.css("background","none");
+                }
+              },function(){});
+            }
+            // If there's no fileEntry.file, then we're in a situation
+            // (like desktop browser) that lacks our Cordova FileDownloader
+            // plugin.
           },
           function(err) {
             // well, that's cool... do nothing then.


### PR DESCRIPTION
Condition the file preview download on presence of the download
machinery.  Also, remove the "Contents not dowloaded" wait dialog - it's
not useful, now, and broken, besides.
