### PR TITLE
Issue #428 - Fix server address settings change so it properly logs out the current account, if any.

### DIFF
--- a/src/models/AccountModel.js
+++ b/src/models/AccountModel.js
@@ -216,10 +216,10 @@
      * @param {string} successCallback - gets data, status code, xhr
      * @param {string} errorCallback - gets status code, status text, xhr
      * @param {string} login_url Optional explicit login location
-     * @param {string} login_optionalHost Optional explicit login domain
+     * @param {string} probeHost Optional explicit login domain, for trial that will not have actual login effect
      */
     login: function(username, password, successCallback, errorCallback,
-                    login_url, optionalHost) {
+                    login_url, probeHost) {
       /* @TODO: Move the notification to a view element, probably LoginView. */
       if (!spiderOakApp.networkAvailable && navigator.notification) {
         navigator.notification.confirm(
@@ -237,17 +237,12 @@
       if (this.getLoginState() === "interrupting") {
         return this.doInterruption();
       }
-      else {
+      else if (! probeHost) {
         this.setLoginState("in-process");
       }
 
       var _self = this,
-          /** A BasicAuth suspending and resuming utility.
-           *
-           * Once instantiated with current credentials, they're stashed,
-           * and aren't neede to reestablish basic auth based on them.
-           */
-          server = (optionalHost ||
+          server = (probeHost ||
                     spiderOakApp.settings.getValue("server")),
           login_url_start = "https://" + server + "/browse/login";
       login_url = login_url || login_url_start;
@@ -262,11 +257,7 @@
           password: password
         },
 
-        /** Handle server login success.
-         *
-         * We may refuse the success, because while the server is tolerant
-         * of variations in the username case, the clients should not be.
-         */
+        /** Handle server login success. */
         success: function(data, status, xhr) {
           var where = data.match(_self.get("response_parse_regex"));
 
@@ -332,7 +323,7 @@
             // Recurse, with adjusted login_url:
             if ((_self.login(username, password,
                              successCallback, errorCallback,
-                             login_url, optionalHost) === "interrupting") &&
+                             login_url, probeHost) === "interrupting") &&
                 errorCallback) {
               errorCallback(0, "interrupted", xhr);
             }
@@ -342,14 +333,18 @@
             if (destination === login_url_start) {
               destination = where[2];
             }
-            loginSuccess(destination, data.slice("location:".length));
+            if (! probeHost) {
+              loginSuccess(destination, data.slice("location:".length));
+            }
           }
           else {
             errorCallback(0, "unexpected server response", xhr);
           }
         },
         error: function(xhr, errorType, error) {
-          _self.setLoginState(false);
+          if (! probeHost) {
+            _self.setLoginState(false);
+          }
           errorCallback(xhr.status, "authentication failed", xhr);
         }
       });

--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -370,6 +370,7 @@
           if (wasLoggedIn) {
             subtitle += "\nand session logged out";
           }
+          // Set the app's actual server setting, which is our model:
           this.model.set("value", newServer);
           spiderOakApp.dialogView.showNotify({
             title: "<i class='icon-info'></i> Server changed",

--- a/tests/models/AccountModel.js
+++ b/tests/models/AccountModel.js
@@ -405,6 +405,10 @@ describe('AccountModel', function() {
       });
     });
 
+    // @TODO Test unsuccessful server addr change - should not change anything
+    // @TODO Test successful server addr change, sans current account
+    // @TODO Test successful server addr change, with current account - logs out
+
     describe('successful alternate login', function() {
       beforeEach(function(){
         this.successSpy = sinon.spy();
@@ -602,7 +606,6 @@ describe('AccountModel', function() {
         this.accountModel.get("mySharesListURL").should.equal("");
         this.accountModel.get("webRootURL").should.equal("");
       });
-      // @TODO: Clear keychain credentials test
       // @TODO: Clear any localStorage test
     });
     describe('login after logout', function() {


### PR DESCRIPTION
Fixes #428, but without new tests.

So much of the sever address change logic is tied to view activity that I can't manageably implement tests. While functional tests might be an expedient way to test it, in this case that the code should be refactored to put more of the logistical activity in the account model, where it would be easily susceptible to unit testing. Issue #429 is tied to the post-3.0 release for that purpose.

I suspect that there is other view code that could be refactored for similar purposes.
