### PR TITLE
Developer alert for bad configs

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -301,11 +301,11 @@
           }
           msg = "Developer: Failed to load" + msg + " custom config";
         }
-      }
-      console.log(msg);
-      if (spiderOakApp.version.split("-").length > 2) {
-        // Developer version - be noisy!
-        navigator.notification.alert(msg);
+        console.log(msg);
+        if (spiderOakApp.version.split("-").length > 2) {
+          // Developer version - be noisy!
+          navigator.notification.alert(msg);
+        }
       }
     },
     checkAlternateServerAllowed: function() {


### PR DESCRIPTION
If the version number includes a few "-" dashes, then be noisy about failure to load the config or custom config. Otherwise, just post a console message.
