### PR TITLE
Make ShareRoom item details URL into an active link.

### DIFF
--- a/src/views/ShareRoomsViews.js
+++ b/src/views/ShareRoomsViews.js
@@ -651,7 +651,8 @@
   spiderOakApp.ShareItemDetailsView = spiderOakApp.FileView.extend({
     destructionPolicy: "never",
     events: {
-      "tap .file-send-button": "sendLink"
+      "tap .file-send-button": "sendLink",
+      "tap .site-link": "siteLink_tapHandler"
     },
     initialize: function(options) {
       window.bindMine(this);
@@ -682,6 +683,15 @@
     viewActivate: function(event) {
       spiderOakApp.backDisabled = false;
       spiderOakApp.mainView.showBackButton(true);
+    },
+    siteLink_tapHandler: function(event) {
+      event.preventDefault();
+      if ($("#main").hasClass("open")) {
+        return;
+      }
+      event.stopPropagation();
+      window.open($(event.target).data("url"), "_system");
+
     },
     viewDeactivate: function(event) {
       // this.close();

--- a/tpl/shareItemDetailsViewTemplate.html
+++ b/tpl/shareItemDetailsViewTemplate.html
@@ -35,7 +35,9 @@
   <ul>
     <li class="sep">URL</li>
     <li class="small" style="font-size:80%;">
+      <a href="#shareroom" data-url='https:\/\/{{=spiderOakApp.settings.get("server").get("value")}}{{=it.browse_url}}/' class="site-link" style="white-space: nowrap;">
       https:\/\/{{=spiderOakApp.settings.get("server").get("value")}}{{=it.browse_url}}/
+      </a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
This is a provisional fix for #505, so that people can tap the link to get to the ShareRoom, and copy the URL from there. After release we'll integrate the long-tap copy plugin, but this will provide an alternative until then.
