### PR TITLE
Respond to empty username and password like any incorrect credentials.

### DIFF
--- a/src/models/AccountModel.js
+++ b/src/models/AccountModel.js
@@ -338,7 +338,12 @@
             }
           }
           else {
-            errorCallback(0, "unexpected server response", xhr);
+            if (username === "") {
+              errorCallback(403, "Authentication failed", xhr);
+            }
+            else {
+              errorCallback(0, "unexpected server response", xhr);
+            }
           }
         },
         error: function(xhr, errorType, error) {


### PR DESCRIPTION
I didn't tweak the UI to disable the login button unless the username and password fields are non-empty, because that kind of code just is more stuff to go wrong. I can do something like that if it's deemed preferable - but having the lower-level handling accommodate the server's eccentricities is a good thing, anyway.

(One might ask why the web API responds to an empty username and password with a 200, but we already know the web API is, peculiar.)

Fixes #509.
