### PR TITLE
Clear the login password field as soon as we've stashed the value.

### DIFF
--- a/src/views/LoginView.js
+++ b/src/views/LoginView.js
@@ -61,7 +61,6 @@
 
       var username = $("#unme").val().trim();
       var password = $("#pwrd").val();
-      $("#pwrd").val("");
       var rememberme = $("#rememberme").attr("checked") === "true";
 
       var success = function(apiRoot) {
@@ -90,13 +89,15 @@
         }
       }.bind(this);
       var error = function(status, error) {
-        // Clear it out
+        // Clear it out, and zero the password:
         account.loggedOut();
-        // @TODO: Unblock spinner
         var msg,
-            silent = false;
+            silent = false,
+            dontClearPassword = false;
+
         if ((status === 0) && (error === "interrupted")) {
           msg = "Authentication interrupted";
+          dontClearPassword = true;
           silent = true;
         }
         else if (status === 401) {
@@ -121,9 +122,13 @@
         else {
           msg = ("Temporary server failure. Please try again later (" +
                  status + ")");
+          dontClearPassword = true;
         }
 
         spiderOakApp.dialogView.hide();
+        if (! dontClearPassword) {
+          $("#pwrd").val("");
+        }
 
         if (! silent) {
           navigator.notification.alert(msg, null, "Authentication error", "OK");

--- a/src/views/ShareRoomsViews.js
+++ b/src/views/ShareRoomsViews.js
@@ -758,7 +758,6 @@
     form_submitHandler: function(event) {
       var passwordField = this.$("[name=pwrd]"),
           password = passwordField.val();
-      passwordField.val("");
       this.model.setPassword(password);
 
       spiderOakApp.dialogView.showWait({
@@ -794,6 +793,7 @@
       }.bind(this);
 
       var handleInvalidPassword = function() {
+        passwordField.val("");
         spiderOakApp.dialogView.hide();
         spiderOakApp.dialogView.showNotify({
           title: "<i class='icon-warning'></i> Invalid password"


### PR DESCRIPTION
While we're at it, clear the ShareRooms password field similarly - unnecessary, since we don't return to the form, but more consistent, in case we ever do return there.

Fixes #513.
