### PR TITLE
Issue 521 public shares and disappearing favorites

### DIFF
--- a/src/views/FilesView.js
+++ b/src/views/FilesView.js
@@ -604,9 +604,11 @@
           spiderOakApp.dialogView.hide();
         };
         // Update the model
+        var fullUrl = model.composedUrl(true);
+        var url = fullUrl.substr(0, fullUrl.lastIndexOf("/") + 1);
         $.ajax({
           type: "GET",
-          url: model.composedUrl(true) + "?format=version_info",
+          url: url,
           headers: {
             "Authorization": (
               model.getBasicAuth() ||
@@ -615,7 +617,9 @@
           success: function(data, status, xhr) {
             // Since we are fetching the version info, the most recent version
             // is what we are after
-            var updatedModelData = _.last(data);
+            var updatedModelData = _.find(data.files, function(file) {
+              return file.url == model.get("encodedUrl");
+            });
             model.set({
               mtime: updatedModelData.mtime,
               size: updatedModelData.size


### PR DESCRIPTION
In the fix for #492 it seems that `?format=version_info` is not available when the file has only the one version

Changed it to get the JSON for the folder and find the file's data inside. Not as pretty, but serviceable.

Fixes #521
