### PR TITLE
Fixes scope issue causing login prelim return on Blue

### DIFF
--- a/src/views/DialogView.js
+++ b/src/views/DialogView.js
@@ -31,7 +31,7 @@
       options.title = options.title || "Please wait";
       options.subtitle = options.subtitle || "";
       this.$el.html(window.tmpl["waitDialog"](options));
-      if (options.showCancel && $.os.ios) $(".cancel-btn").show();
+      if (options.showCancel && $.os.ios) this.$(".cancel-btn").show();
       this.$el.show();
     },
     showNotifyErrorResponse: function(response, options) {
@@ -91,7 +91,7 @@
       options.subtitle = options.subtitle || "";
       options.start = options.start || 0;
       this.$el.html(window.tmpl["progressDialog"](options));
-      if (options.showCancel && $.os.ios) $(".cancel-btn").show();
+      if (options.showCancel && $.os.ios) this.$(".cancel-btn").show();
       this.$el.show();
     },
     updateProgress: function(progressPercent) {


### PR DESCRIPTION
missing scope on a hide() caused a situation where if you viewed a file from a ShareRoom then went back to the login screen, the "X" button sending you to the prelim screen reappeared.

10:31 < Becca> create a public share room, do share stuff, go to the side menu
               and click "Login In"
10:31 < Becca> takes you back to _almost_ the same login page, but now there's an
               X in the top right corner
10:31 < Becca> X marks the spot
10:31 < Becca> X -> Blue need an account page
