### PR TITLE
Issue 573 - File download progress callback varying by platform

### DIFF
--- a/src/views/FilesView.js
+++ b/src/views/FilesView.js
@@ -111,8 +111,10 @@
         fsType: window.LocalFileSystem.PERSISTENT,
         onprogress: function onprogress(progressEvent) {
           if (progressEvent.lengthComputable) {
+            var percentMultiplier = (($.os.android)?1:0.5);
             var percentComplete =
-                  ((progressEvent.loaded / 2) / progressEvent.total) * 100;
+                  ((progressEvent.loaded * percentMultiplier) / progressEvent.total) * 100;
+                  // ((progressEvent.loaded) / progressEvent.total) * 100;
             percentComplete = percentComplete <= 100 ? percentComplete : 100;
             spiderOakApp.dialogView.updateProgress(percentComplete);
           }
@@ -394,8 +396,10 @@
         fsType: window.LocalFileSystem.TEMPORARY,
         onprogress: function onprogress(progressEvent) {
           if (progressEvent.lengthComputable) {
+            var percentMultiplier = (($.os.android)?1:0.5);
             var percentComplete =
-                  ((progressEvent.loaded / 2) / progressEvent.total) * 100;
+                  ((progressEvent.loaded * percentMultiplier) / progressEvent.total) * 100;
+                  // ((progressEvent.loaded) / progressEvent.total) * 100;
             percentComplete = percentComplete <= 100 ? percentComplete : 100;
             spiderOakApp.dialogView.updateProgress(percentComplete);
           }


### PR DESCRIPTION
Progress varies by platform again....

_sigh_ It seems that the progress varies by platform again with the new file transfer plugin.

This sets the multiplier on a per platform basis.

fixes #573 
