### PR TITLE
Exempt any files with names matching "gitignore-*" from checkin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/**/gitignore-*
 www/components/**/*
 bower_components/**/*
 !www/components/.gitignore


### PR DESCRIPTION
Handy dandy.

The only reservation I have is that I can no longer depend on git status revealing to me that I have a special item around. I think this is a "can't have your cake and eat it, too" kind of thing.
