### PR TITLE
Should not unset passcode when unsetting stay logged in

### DIFF
--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -133,9 +133,6 @@
         }
       }
       else {
-        if (spiderOakApp.accountModel.getPasscode()) {
-          spiderOakApp.accountModel.unsetPasscode();
-        }
         spiderOakApp.settings.remove("rememberedAccount");
         spiderOakApp.accountModel.set("rememberme",rememberme);
         spiderOakApp.settings.saveRetainedSettings();


### PR DESCRIPTION
Fixes #591 

Passcodes are useful without stay logged in.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/kenmanheimer%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/515685%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/pull/608%23issuecomment-63543200%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222014-11-18T20%3A56%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/515685%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kenmanheimer%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Commit%202ba414405441f6573068ad11d85a945b18955695%20src/views/SettingsView.js%204%20136%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/commit/2ba414405441f6573068ad11d85a945b18955695%23commitcomment-8622983%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20occurs%20to%20me%20that%20having%20the%20passcode%20locking%20that%20app%20without%20being%20logged%20in%20could%20be%20a%20real%20problem%2C%20because%20then%20you%20can%27t%20really%20log%20out%20to%20unlock%20it.%20I%20assume%20that%20the%20app%20will%20still%20offer%20the%20logout%20option%2C%20even%20if%20you%27re%20not%20logged%20in%2C%20but%20I%20have%20to%20confirm%20that.%5Cr%5Cn%5Cr%5Cn%28I%20also%20am%20trying%20the%20codereviewhub.com%20stuff%20-%20glad%20that%20someone%20got%20it%20installed%2C%20since%20I%20was%20couldn%27t%2C%20%20due%20to%20not%20being%20repo%20owner%20-%20%40merickson%3F%29%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222014-11-18T20%3A34%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/515685%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kenmanheimer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28Wow%2C%20the%20codereviewhub%20stuff%20is%20what%20I%20hoped%20-%20cool%21%29%22%2C%20%22created_at%22%3A%20%222014-11-18T20%3A36%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/515685%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kenmanheimer%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20passcode%20doesn%27t%20lock%20the%20app%20unless%20you%20%2Aare%2A%20logged%20in.%5Cr%5Cn%5Cr%5CnIt%20just%20means%20that%20while%20you%20are%20logged%20in%20and%20the%20app%20is%20in%20the%20background%2C%20you%20can%20still%20lock%20the%20app%20with%20a%20passcode.%22%2C%20%22created_at%22%3A%20%222014-11-18T20%3A39%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/554999%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/devgeeks%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yep%20-%20beautiful.%20The%20locking%20works%20as%20hoped.%5Cr%5Cn%5Cr%5Cn%28It%20also%20occurred%20to%20me%20to%20wonder%20if%20ShareRooms%20passwords%20are%20handled%20properly%20-%20specifically%2C%20the%20password%20is%20removed%20on%20logout%2C%20if%20it%20was%20provided%20while%20logged%20in%2C%20and%20that%27s%20exactly%20how%20it%27s%20working.%20Even%20more%20than%20I%20expected%2C%20the%20passwords%20are%20removed%20only%20if%20they%20were%20added%20during%20that%20login.%20I%27m%20surprised%20there%27s%20that%20much%20discretion%20-%20and%20I%20think%20I%20implemented%20it...%20%7C-%25%5Cr%5Cn%5Cr%5CnHowever%2C%20I%27m%20diverted%20with%20problems%20entering%20a%20password%20for%20a%20particular%20ShareRoom.%20I%27ll%20investigate%20that%20separately%20-%20this%20is%20good%20to%20go.%20%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222014-11-18T20%3A56%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/515685%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kenmanheimer%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/views/SettingsView.js%3AL136%20%282ba4144%29%22%7D%2C%20%22Commit%202ba414405441f6573068ad11d85a945b18955695%20src/views/SettingsView.js%206%20138%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/commit/2ba414405441f6573068ad11d85a945b18955695%23commitcomment-8623276%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22A%20separate%2C%20totally%20gratuitous%20comment%2C%20for%20the%20sake%20of%20testing%20the%20codereviewhub%20stuff.%22%2C%20%22created_at%22%3A%20%222014-11-18T20%3A55%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/515685%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kenmanheimer%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/views/SettingsView.js%3AL138%20%282ba4144%29%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/pull/608%23issuecomment-63543200%22%2C%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/commit/2ba414405441f6573068ad11d85a945b18955695%23commitcomment-8622983%22%2C%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/commit/2ba414405441f6573068ad11d85a945b18955695%23commitcomment-8623019%22%2C%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/commit/2ba414405441f6573068ad11d85a945b18955695%23commitcomment-8623061%22%2C%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/commit/2ba414405441f6573068ad11d85a945b18955695%23commitcomment-8623276%22%2C%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/commit/2ba414405441f6573068ad11d85a945b18955695%23commitcomment-8623280%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/kenmanheimer'><img src='https://avatars.githubusercontent.com/u/515685?v=3' width=34 height=34></a>
- [x] <a href='#crh-comment-Commit 2ba414405441f6573068ad11d85a945b18955695 src/views/SettingsView.js 6 138'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/SpiderOak/SpiderOakMobileClient/commit/2ba414405441f6573068ad11d85a945b18955695#commitcomment-8623276'>File: src/views/SettingsView.js:L138 (2ba4144)</a></b>
- <a href='https://github.com/kenmanheimer'><img border=0 src='https://avatars.githubusercontent.com/u/515685?v=3' height=16 width=16'></a> A separate, totally gratuitous comment, for the sake of testing the codereviewhub stuff.
- [x] <a href='#crh-comment-Commit 2ba414405441f6573068ad11d85a945b18955695 src/views/SettingsView.js 4 136'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/SpiderOak/SpiderOakMobileClient/commit/2ba414405441f6573068ad11d85a945b18955695#commitcomment-8622983'>File: src/views/SettingsView.js:L136 (2ba4144)</a></b>
- <a href='https://github.com/kenmanheimer'><img border=0 src='https://avatars.githubusercontent.com/u/515685?v=3' height=16 width=16'></a> It occurs to me that having the passcode locking that app without being logged in could be a real problem, because then you can't really log out to unlock it. I assume that the app will still offer the logout option, even if you're not logged in, but I have to confirm that.
  (I also am trying the codereviewhub.com stuff - glad that someone got it installed, since I was couldn't,  due to not being repo owner - @merickson?)
- <a href='https://github.com/kenmanheimer'><img border=0 src='https://avatars.githubusercontent.com/u/515685?v=3' height=16 width=16'></a> (Wow, the codereviewhub stuff is what I hoped - cool!)
- <a href='https://github.com/devgeeks'><img border=0 src='https://avatars.githubusercontent.com/u/554999?v=3' height=16 width=16'></a> The passcode doesn't lock the app unless you _are_ logged in.
  It just means that while you are logged in and the app is in the background, you can still lock the app with a passcode.
- <a href='https://github.com/kenmanheimer'><img border=0 src='https://avatars.githubusercontent.com/u/515685?v=3' height=16 width=16'></a> Yep - beautiful. The locking works as hoped.
  (It also occurred to me to wonder if ShareRooms passwords are handled properly - specifically, the password is removed on logout, if it was provided while logged in, and that's exactly how it's working. Even more than I expected, the passwords are removed only if they were added during that login. I'm surprised there's that much discretion - and I think I implemented it... |-%
  However, I'm diverted with problems entering a password for a particular ShareRoom. I'll investigate that separately - this is good to go. :shipit:

<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/608?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/608?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/608?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/608'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
