### PR TITLE
Use the English version of "Zero-Knowledge" in the Spanish translation.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "iscroll": "https://github.com/cubiq/iscroll/archive/v4.2.zip",
     "modernizr": "2.6.3",
     "moment": "~2.8.0",
-    "html10n": "https://github.com/SpiderOak/html10n.js.git#fix-for-cordova-locale-imports",
+    "html10n": "https://github.com/SpiderOak/html10n.js.git#spideroak",
     "store.js": "1.3.x"
   }
 }

--- a/tpl/needAnAccountViewTemplate.html
+++ b/tpl/needAnAccountViewTemplate.html
@@ -8,7 +8,7 @@
   <div class="about-spideroak-content">
     <p>{{= qq("The [[SpiderOak]] [[platform]] application provides an easy way to access your data on the move, open ShareRooms, view historical versions, and quickly email files to friends, colleagues, and/or clients.", {'SpiderOak': s('SpiderOak'),'platform':it.platform})}}</p>
     <p>
-      <span>{{= qq("In order to ensure 'Zero-Knowledge' Privacy, your account must be created on a computer.")}}</span>
+      <span>{{= qq("In order to ensure '[[Zero-Knowledge]]' Privacy, your account must be created on a computer.", {"Zero-Knowledge": "Zero-Knowledge"})}}</span>
       {{? !$.os.ios }}
       <span> {{= qq("Please go to <a href='#spideroak' data-url='https:\/\/[[sourl]] class='site-link' style='white-space: nowrap;'>https:\/\/[[sourl]]</a> and follow the instructions to establish your account.", {"sourl": s("spideroak.com")})}}</span>{{? }}</p>
     <p><span>{{= qq("Live Privately,")}}</span><br>

--- a/tpl/nonZKWarningViewTemplate.html
+++ b/tpl/nonZKWarningViewTemplate.html
@@ -1,13 +1,13 @@
 <div>
   <div class="nonzk-warning-content">
-    <h3 style="text-align: center;">{{= qq("
-      Not 'Zero-Knowledge'
-    ")}}</h3>
+    <h3 style="text-align: center;">
+      {{= qq("Not '[[Zero-Knowledge]]'", {"Zero-Knowledge": "Zero-Knowledge"})}}
+    </h3>
 
     <p style="padding: 0 10px;">
       <span>{{= qq("If you login with this mobile client, or via the website, your password will exist in the [[SpiderOak]] server memory during your browsing session. However, your password will be stored in encrypted memory and never written to an unencrypted disk. When your session is done the server's copy of your password is completely erased.", {'SpiderOak': s('SpiderOak')})}}</span>
 <br><br>
-<span>{{= qq("If you prefer to use only 'Zero-Knowledge' access, cancel this login, and only login via the [[SpiderOak]] desktop client.", {'SpiderOak': s('SpiderOak')})}}</span>
+<span>{{= qq("If you prefer to use only '[[Zero-Knowledge]]' access, cancel this login, and only login via the [[SpiderOak]] desktop client.", {'SpiderOak': s('SpiderOak'), "Zero-Knowledge": "Zero-Knowledge"})}}</span>
     </p>
     <div>
       <a class="button continue">{{= qq("Continue logging in")}}</a>

--- a/www/locales/en-US.json
+++ b/www/locales/en-US.json
@@ -200,11 +200,11 @@
     "The SpiderOak Team": "The SpiderOak Team",
 
     "Zero-Knowledge": "Zero-Knowledge",
-    "Not '[[Zero-Knowledge]]'": "Not 'Zero-Knowledge'",
+    "Not '[[Zero-Knowledge]]'": "Not '{{Zero-Knowledge}}'",
     "If you login with this mobile client, or via the website, your password will exist in the [[SpiderOak]] server memory during your browsing session. However, your password will be stored in encrypted memory and never written to an unencrypted disk. When your session is done the server's copy of your password is completely erased."
     : "If you login with this mobile client, or via the website, your password will exist in the {{SpiderOak}} server memory during your browsing session. However, your password will be stored in encrypted memory and never written to an unencrypted disk. When your session is done the server's copy of your password is completely erased.",
     "If you prefer to use only '[[Zero-Knowledge]]' access, cancel this login, and only login via the [[SpiderOak]] desktop client."
-: "If you prefer to use only 'Zero-Knowledge' access, cancel this login, and only login via the {{SpiderOak}} desktop client.",
+: "If you prefer to use only '{{Zero-Knowledge}}' access, cancel this login, and only login via the {{SpiderOak}} desktop client.",
     "Continue logging in": "Continue logging in",
     "Don't login now": "Don't login now",
 
@@ -335,7 +335,7 @@
     : "Need an account?<br>Register now &raquo;",
 
     "In order to ensure '[[Zero-Knowledge]]' Privacy, your account must be created on a computer."
-    : "In order to ensure 'Zero-Knowledge' Privacy, your account must be created on a computer.",
+    : "In order to ensure '{{Zero-Knowledge}}' Privacy, your account must be created on a computer.",
 
     "NO TRAILING COMMA": "NO TRAILING COMMA"
   }

--- a/www/locales/en-US.json
+++ b/www/locales/en-US.json
@@ -199,11 +199,12 @@
     "Live Privately,": "Live Privately,",
     "The SpiderOak Team": "The SpiderOak Team",
 
-    "Not 'Zero-Knowledge'": "Not 'Zero-Knowledge'",
+    "Zero-Knowledge": "Zero-Knowledge",
+    "Not '[[Zero-Knowledge]]'": "Not 'Zero-Knowledge'",
     "If you login with this mobile client, or via the website, your password will exist in the [[SpiderOak]] server memory during your browsing session. However, your password will be stored in encrypted memory and never written to an unencrypted disk. When your session is done the server's copy of your password is completely erased."
     : "If you login with this mobile client, or via the website, your password will exist in the {{SpiderOak}} server memory during your browsing session. However, your password will be stored in encrypted memory and never written to an unencrypted disk. When your session is done the server's copy of your password is completely erased.",
-    "If you prefer to use only 'Zero-Knowledge' access, cancel this login, and only login via the [[SpiderOak]] desktop client."
-    : "If you prefer to use only 'Zero-Knowledge' access, cancel this login, and only login via the {{SpiderOak}} desktop client.",
+    "If you prefer to use only '[[Zero-Knowledge]]' access, cancel this login, and only login via the [[SpiderOak]] desktop client."
+: "If you prefer to use only 'Zero-Knowledge' access, cancel this login, and only login via the {{SpiderOak}} desktop client.",
     "Continue logging in": "Continue logging in",
     "Don't login now": "Don't login now",
 
@@ -278,7 +279,7 @@
     "Open in": "Open in",
 
     "MS Word": "MS Word",
-    "MS Excel":  "MS Excel",
+    "MS Excel": "MS Excel",
     "MS PowerPoint": "MS PowerPoint",
     "Adobe PDF": "Adobe PDF",
     "Zip Archive": "Zip Archive",
@@ -333,7 +334,7 @@
     "Need an account?<br>Register now &raquo;"
     : "Need an account?<br>Register now &raquo;",
 
-    "In order to ensure 'Zero-Knowledge' Privacy, your account must be created on a computer."
+    "In order to ensure '[[Zero-Knowledge]]' Privacy, your account must be created on a computer."
     : "In order to ensure 'Zero-Knowledge' Privacy, your account must be created on a computer.",
 
     "NO TRAILING COMMA": "NO TRAILING COMMA"

--- a/www/locales/es.json
+++ b/www/locales/es.json
@@ -260,5 +260,5 @@
   "In order to ensure '[[Zero-Knowledge]]' Privacy, your account must be created on a computer."
   : "Para asegurar Privacidad '{{Zero-Knowledge}}', su cuenta debe ser creada en una computadora.",
 
-  "#END:": "sin comas colgantes"
+  "sin comas colgantes": "sin comas colgantes"
 }

--- a/www/locales/es.json
+++ b/www/locales/es.json
@@ -143,9 +143,9 @@
   "Please go to <a href='#spideroak' data-url='https://[[sourl]] class='site-link' style='white-space: nowrap;'>https://[[sourl]]</a> and follow the instructions to establish your account.": "Diríjase a <a href='#spideroak' data-url='https://{{sourl}} class='site-link' style='white-space: nowrap;'>https://{{sourl}}</a> y siga las instrucciones para establecer su cuenta.",
   "Live Privately,": "Viva en forma privada,",
   "The SpiderOak Team": "El equipo de SpiderOak",
-  "Not 'Zero-Knowledge'": "Sin sistema \"cero conocimiento\"",
+  "Not '[[Zero-Knowledge]]'": "Sin sistema \"Zero-Knowledge\"",
   "If you login with this mobile client, or via the website, your password will exist in the [[SpiderOak]] server memory during your browsing session. However, your password will be stored in encrypted memory and never written to an unencrypted disk. When your session is done the server's copy of your password is completely erased.": "Si inicia sesión con este cliente móvil, o a través del sitio web, su contraseña existirá en la memoria del servidor de {{SpiderOak}} durante su sesión de navegación. Sin embargo, su contraseña se almacenará en memoria cifrada y nunca se guardará en un disco no codificado. Cuando cierre su sesión, la copia de su contraseña en el servidor se borrará completamente.",
-  "If you prefer to use only 'Zero-Knowledge' access, cancel this login, and only login via the [[SpiderOak]] desktop client.": "Si prefiere utilizar solo el acceso \"cero conocimiento\", cancele este inicio de sesión e inicie sesión a través del cliente de escritorio de {{SpiderOak}}.",
+  "If you prefer to use only '[[Zero-Knowledge]]' access, cancel this login, and only login via the [[SpiderOak]] desktop client.": "Si prefiere utilizar solo el acceso \"Zero-Knowledge\", cancele este inicio de sesión e inicie sesión a través del cliente de escritorio de {{SpiderOak}}.",
   "Continue logging in": "Continuar el inicio de sesión",
   "Don't login now": "No iniciar sesión ahora",
   "Passcode unlock": "Desbloqueo de código de acceso",
@@ -257,7 +257,7 @@
   "Need an account?<br>Register now &raquo;"
   : "¿Necesitas una cuenta?<br>Registrarse ahora &raquo;",
 
-  "In order to ensure 'Zero-Knowledge' Privacy, your account must be created on a computer."
+  "In order to ensure '[[Zero-Knowledge]]' Privacy, your account must be created on a computer."
   : "Para asegurar Privacidad 'Zero-Knowledge', su cuenta debe ser creada en una computadora.",
 
   "#END:": "sin comas colgantes"

--- a/www/locales/es.json
+++ b/www/locales/es.json
@@ -143,9 +143,9 @@
   "Please go to <a href='#spideroak' data-url='https://[[sourl]] class='site-link' style='white-space: nowrap;'>https://[[sourl]]</a> and follow the instructions to establish your account.": "Diríjase a <a href='#spideroak' data-url='https://{{sourl}} class='site-link' style='white-space: nowrap;'>https://{{sourl}}</a> y siga las instrucciones para establecer su cuenta.",
   "Live Privately,": "Viva en forma privada,",
   "The SpiderOak Team": "El equipo de SpiderOak",
-  "Not '[[Zero-Knowledge]]'": "Sin sistema \"Zero-Knowledge\"",
+  "Not '[[Zero-Knowledge]]'": "Sin sistema \"{{Zero-Knowledge}}\"",
   "If you login with this mobile client, or via the website, your password will exist in the [[SpiderOak]] server memory during your browsing session. However, your password will be stored in encrypted memory and never written to an unencrypted disk. When your session is done the server's copy of your password is completely erased.": "Si inicia sesión con este cliente móvil, o a través del sitio web, su contraseña existirá en la memoria del servidor de {{SpiderOak}} durante su sesión de navegación. Sin embargo, su contraseña se almacenará en memoria cifrada y nunca se guardará en un disco no codificado. Cuando cierre su sesión, la copia de su contraseña en el servidor se borrará completamente.",
-  "If you prefer to use only '[[Zero-Knowledge]]' access, cancel this login, and only login via the [[SpiderOak]] desktop client.": "Si prefiere utilizar solo el acceso \"Zero-Knowledge\", cancele este inicio de sesión e inicie sesión a través del cliente de escritorio de {{SpiderOak}}.",
+  "If you prefer to use only '[[Zero-Knowledge]]' access, cancel this login, and only login via the [[SpiderOak]] desktop client.": "Si prefiere utilizar solo el acceso \"{{Zero-Knowledge}}\", cancele este inicio de sesión e inicie sesión a través del cliente de escritorio de {{SpiderOak}}.",
   "Continue logging in": "Continuar el inicio de sesión",
   "Don't login now": "No iniciar sesión ahora",
   "Passcode unlock": "Desbloqueo de código de acceso",
@@ -258,7 +258,7 @@
   : "¿Necesitas una cuenta?<br>Registrarse ahora &raquo;",
 
   "In order to ensure '[[Zero-Knowledge]]' Privacy, your account must be created on a computer."
-  : "Para asegurar Privacidad 'Zero-Knowledge', su cuenta debe ser creada en una computadora.",
+  : "Para asegurar Privacidad '{{Zero-Knowledge}}', su cuenta debe ser creada en una computadora.",
 
   "#END:": "sin comas colgantes"
 }


### PR DESCRIPTION
@devgeeks - It would be good to do another build, look it over, and see @merickson can get BP to use this one instead of the previous, so `Zero-Knowledge` is kept untranslated...
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/629?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/629'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>