### PR TITLE
Workaround html10n problem with qualified coutnry codes.

### DIFF
--- a/src/helpers/localizer.js
+++ b/src/helpers/localizer.js
@@ -32,8 +32,9 @@
 
           // @XXX Workaround html10n.build() bizarre behavior with arrays
           // that include "es-es".
-          if (candidate === "es-es") {
-            candidate = "es";
+          if ((candidate.indexOf("-") !== -1) &&
+              candidate.split("-")[0] !== "en") {
+            candidate = candidate.split("-")[0];
           }
 
           // Already included?

--- a/www/locales/es.json
+++ b/www/locales/es.json
@@ -260,5 +260,5 @@
   "In order to ensure '[[Zero-Knowledge]]' Privacy, your account must be created on a computer."
   : "Para asegurar Privacidad '{{Zero-Knowledge}}', su cuenta debe ser creada en una computadora.",
 
-  "sin comas colgantes": "sin comas colgantes"
+  "NO TRAILING COMMA": "sin comas colgantes"
 }


### PR DESCRIPTION
Reduce any but en-* qualfiied ones to unqualified.

en-* qualified ones will still clobber the trailing entries - but with
"en", which is the fallback we want, anyway.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/630?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/630'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>