### PR TITLE
Start username phase-out, by asking for/presenting "Email/Username"

### DIFF
--- a/tpl/settingsAccountViewTemplate.html
+++ b/tpl/settingsAccountViewTemplate.html
@@ -5,23 +5,10 @@
       <div class="info">{{!it.firstname + " " + it.lastname}}</div>
       <div class="clearfix"></div>
     </li>
-    {{ if (spiderOakApp.b32nibbler.decode(
-               spiderOakApp.accountModel.get("b32username")
-          ) !== it.loginname) { }}
     <li>
-      <div class="label">Login name</div>
+      <div class="label">Email/Username</div>
       <div class="info">
         {{!it.loginname}}
-      </div>
-      <div class="clearfix"></div>
-    </li>
-    {{ } }}
-    <li>
-      <div class="label">Username</div>
-      <div class="info">
-        {{!spiderOakApp.b32nibbler.decode(
-          spiderOakApp.accountModel.get("b32username")
-        )}}
       </div>
       <div class="clearfix"></div>
     </li>

--- a/www/index.html
+++ b/www/index.html
@@ -41,7 +41,7 @@
           <div class="login-input">
             <input id="unme" type="text" name="unme"
                        autocorrect="off" autocapitalize="off" 
-                       placeholder="Username"
+                       placeholder="Email/Username"
                        tabindex="1" />
           </div>
           <div class="spacer5"></div>


### PR DESCRIPTION
In the settings account view, we were already presenting the "Login
name" if it differed from the username. Now the logic is simpler - we
remove the condition and just present what was in this Login name field,
which is whatever the user logged in with, and don't bother with what the
"Username" field.  To my current knowledge, this is the best we can do.

The layout constraints seem ok, reasonably truncating the fields so the
actual data gets space.

Fixes #635.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/639?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/639'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>