### PR TITLE
Client certificate auth added in brands

### DIFF
--- a/.cordova/hooks/after_prepare/customize.js
+++ b/.cordova/hooks/after_prepare/customize.js
@@ -133,7 +133,12 @@
    * @param{string} target name to match a filename in dir
    */
   function matchesInDir(target, dir) {
-    var entries = fs.readdirSync(dir) || [],
+    var safeReaddirSync = function(dir) { try { return(fs.readdirSync(dir)); }
+                                          catch (e) {
+                                            if (e.code === "ENOENT") {
+                                              return [];
+                                            } else { throw e; }}},
+        entries = safeReaddirSync(dir) || [],
         asRegexp = target.charAt(0) === "^",
         got = entries.filter(function (name) {
           return asRegexp ? name.match(target) : (name === target);

--- a/custom/elements.json
+++ b/custom/elements.json
@@ -46,33 +46,35 @@
       "Platforms": ["iOS"]
     },
     {
-      "SourceFileName": "^.*\\.cer$",
+      "SourceFileName": "^.*\\.(cer|p12|json)$",
       "GetCustomElementsFrom": "./certificates",
       "TargetFolder": "assets",
       "Format": "X.509 SSL certificate",
-      "Purpose": "Project-wide server certificates, for cert pinning",
+      "Purpose": "Project-wide server certificates, for cert pinning and auth",
       "Platforms": ["Android"]
     },
     {
-      "SourceFileName": "^.*\\.cer$",
+      "SourceFileName": "^.*\\.(cer|p12|json)$",
       "TargetFolder": "assets",
+      "GetCustomElementsFrom": "./custom/brand/certificates",
       "Format": "X.509 SSL certificate",
-      "Purpose": "Brand-specific server certificates, for cert pinning",
+      "Purpose": "Brand-specific server certificates, for cert pinning and auth",
       "Platforms": ["Android"]
     },
     {
-      "SourceFileName": "^.*\\.cer$",
+      "SourceFileName": "^.*\\.(cer|p12|json)$",
       "GetCustomElementsFrom": "./certificates",
       "TargetAction": "iOSaddCertificate",
       "Format": "X.509 SSL certificate",
-      "Purpose": "Project-wide server certificates, for cert pinning",
+      "Purpose": "Project-wide server certificates, for cert pinning and auth",
       "Platforms": ["iOS"]
     },
     {
-      "SourceFileName": "^.*\\.cer$",
+      "SourceFileName": "^.*\\.(cer|p12|json)$",
       "TargetAction": "iOSaddCertificate",
+      "GetCustomElementsFrom": "./custom/brand/certificates",
       "Format": "X.509 SSL certificate",
-      "Purpose": "Brand-specific server certificates, for cert pinning",
+      "Purpose": "Brand-specific server certificates, for cert pinning and auth",
       "Platforms": ["iOS"]
     },
     {

--- a/custom/scripts/BrandPackage.js
+++ b/custom/scripts/BrandPackage.js
@@ -24,7 +24,7 @@
  *
  * Lastly, an easter-egg for developers of this script:
  *
- * - prefix a brand-name argument with a "," to skip removal+re-creation 
+ * - prefix a brand-name argument with a "," to skip removal+re-creation
  *   of the cordova platforms.
  *
  * @param {string} The name of the brand directory, in <repo>/custom/brands/, or `-' for initializing
@@ -51,7 +51,7 @@ var fs = require('fs'),
     platformsDir = path.join(projectRootDir, "platforms"),
     localCordova = path.join(projectRootDir, "node_modules", ".bin",
                              "cordova");
-    thePlatforms = "ios android";
+    var thePlatforms = "ios android";
 
 /** Driver, for when this module is run as a script.
  *
@@ -72,7 +72,7 @@ function main(executive, scriptName, brandName) {
   }
 
   if (reporting) {
-    report()
+    report();
   }
   else if (priming) {
     prime();
@@ -140,7 +140,7 @@ function prime() {
 function getCurrentBrandName() {
   var got, exc;
   try { got = fs.readlinkSync(brandSymlinkLocation); }
-  catch (exc) { return undefined; };
+  catch (exc) { return undefined; }
   return (fs.existsSync(path.resolve(path.dirname(
     brandSymlinkLocation), got)) &&
           path.basename(got));
@@ -153,7 +153,7 @@ function getCurrentBrandName() {
 function getCurrentBrandProjectConfig() {
   var got, exc;
   try { got = fs.readlinkSync(brandSymlinkLocation); }
-  catch (exc) { return undefined; };
+  catch (exc) { return undefined; }
   return (fs.existsSync(path.resolve(projectConfigFilePath)) &&
           // Use fs.realpathSync() to work around require module cache:
           require(fs.realpathSync(projectConfigFilePath)));
@@ -238,7 +238,7 @@ function removeBrandPluginsByCurrentConfig() {
     var removeCmd = localCordova + " plugins remove " + pluginIds.join(" ");
     blather("Removing prior brand (" + config.projectName +
             ") cordova plugins: " + removeCmd);
-    code = shell.exec(removeCmd).code;
+    var code = shell.exec(removeCmd).code;
     if (code !== 0) {
       blather("Ignoring plugins remove failure (" + code + "): " + removeCmd);
     }
@@ -267,10 +267,10 @@ function addBrandPluginsByCurrentConfig() {
     for (var i in pluginPaths) {
       var addCmd = localCordova + " plugins add " + pluginPaths[i];
       blather(addCmd + "...");
-      code = shell.exec(addCmd).code;
+      var code = shell.exec(addCmd).code;
       if (code !== 0) {
         blather("Plugins add failed (" + code + ") - quitting.");
-        process.exit(1)
+        process.exit(1);
       }
     }
   }
@@ -321,12 +321,12 @@ function adjustManifestsToBrand() {
 function fabricateConfigFromTemplate(resultPath, templatePath,
                                      projectConfig, transforms) {
   var ext = path.extname(resultPath),
-      transformer = ((ext === ".plist") ?
+      Transformer = ((ext === ".plist") ?
                      PlistTemplateTransformer :
                      XMLTemplateTransformer),
-      subject = new transformer(templatePath, resultPath);
+      subject = new Transformer(templatePath, resultPath);
 
-  for (i in transforms) {
+  for (var i in transforms) {
     var curSpec = transforms[i],
         field = curSpec.field,
         tagPath = curSpec.tagPath,
@@ -364,7 +364,7 @@ function createCordovaPlatforms() {
     code = shell.exec(removeCmd).code;
     if (code !== 0) {
       blather("Platforms remove failed (" + code + "): " + addCmd);
-      process.exit(1)
+      process.exit(1);
     }
   }
   addCmd = localCordova + " platform add " + thePlatforms;
@@ -373,7 +373,7 @@ function createCordovaPlatforms() {
   code = shell.exec(addCmd).code;
   if (code !== 0) {
     blather("Platforms add failed (" + code + "): " + addCmd);
-    process.exit(1)
+    process.exit(1);
   }
 }
 
@@ -395,7 +395,11 @@ function XMLTemplateTransformer(templatePath, resultPath) {
 }
 XMLTemplateTransformer.prototype.replace = function(value, tagPath, attr) {
   var tag = this.subject.find(tagPath);
-  attr ? tag.set(attr, value) : tag.text = value;
+  if (attr) {
+    tag.set(attr, value);
+  } else {
+    tag.text = value;
+  }
 };
 XMLTemplateTransformer.prototype.toString = function() {
   return this.subject.write({indent: true});
@@ -412,7 +416,7 @@ function relativeToProjectRoot(thePath) {
   return path.relative(projectRootDir, thePath);
 }
 function blather(message) {
-  console.log("[BrandPackage] %s", message)
+  console.log("[BrandPackage] %s", message);
 }
 
 if (require.main === module) {

--- a/src/views/LoginView.js
+++ b/src/views/LoginView.js
@@ -30,7 +30,7 @@
     },
     render: function() {
       this.$(".learn-more").html(
-        qq("Learn more about [[SpiderOak]]&raquo;",
+        qq("Learn more about [[SpiderOak]] &raquo;",
            {SpiderOak: s("SpiderOak")})
       );
       this.$(".remember-me").html(qq("Stay logged in"));


### PR DESCRIPTION
Copy client cert and config to assets/Resources

I have extended the `elements.json` certificate copying provisions to also copy the `clientauth.json` and `clientcert/p12` needed for client certificate authentication. It has also had the location for these files moved to the brand's `./certificates` folder.

I have also cleaned up a missing space in the "learn more" linking the index.html as well as a large joshing-fuelled touch up for `BrandPackage.js`
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/pull/648%23issuecomment-75308022%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/pull/648%23issuecomment-75308022%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27ve%20made%20a%20small%20change%20to%20customize.js%20to%20tolerate%20absence%20of%20action%20source%20dirs.%20This%20is%20necessary%2C%20eg%2C%20for%20the%20new%20configuration%20with%20brands%20that%20lack%20a%20%27certificates%27%20subdir.%22%2C%20%22created_at%22%3A%20%222015-02-20T19%3A55%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/515685%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kenmanheimer%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/648#issuecomment-75308022'>General Comment</a></b>
- <a href='https://github.com/kenmanheimer'><img border=0 src='https://avatars.githubusercontent.com/u/515685?v=3' height=16 width=16'></a> I've made a small change to customize.js to tolerate absence of action source dirs. This is necessary, eg, for the new configuration with brands that lack a 'certificates' subdir.


<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/648?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/648?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/648'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>