### PR TITLE
Treat 403 and 404 login responses the same.

### DIFF
--- a/src/views/LoginView.js
+++ b/src/views/LoginView.js
@@ -145,11 +145,10 @@
         else if (status === 401) {
           msg = qq("Authentication failed - Unauthorized.");
         }
-        else if (status === 403) {
-          msg = qq("Authentication failed - Incorrect email/username or password.");
-        }
-        else if (status === 404) {
-          msg = qq("Incorrect [[ShareID]] or [[RoomKey]].");
+        else if ([403,404].indexOf(status) != -1) {
+          msg = qq(
+            "Authentication failed - Incorrect email/username or password."
+          );
         }
         else if (status === 418) {
           // SpiderOak uses "teapot" to signal incomplete account - no devices.


### PR DESCRIPTION
Not sure why, but sometimes object server returns 404 for unsuccessful
credentials, but usually 403. Also not sure why we were treating 404 as
Incorrect ShareID or RoomKey, but it's not right.

Fixes #614.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/651?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/651'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>