### PR TITLE
Find the right place to inhibit warnings during tests.

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -1,7 +1,3 @@
-beforeEach(function() {
-  window.html10n.quiet = true;
-});
-
 /*jshint expr:true */
 describe('Application setup', function() {
   describe('components', function() {

--- a/www/tests/index.html
+++ b/www/tests/index.html
@@ -39,6 +39,9 @@
     <script src="../components/semver/semver.browser.js"></script>
     <script src="../components/moment/moment.js"></script>
     <script src="../components/html10n/l10n.js"></script>
+    <script>
+      html10n.quiet = true;
+    </script>
     <link rel="localizations" href="../i18n.json"
           type="application/l10n+json"/>
     <!-- chai-jquery - after zepto -->

--- a/www/tests/index.html
+++ b/www/tests/index.html
@@ -40,7 +40,7 @@
     <script src="../components/moment/moment.js"></script>
     <script src="../components/html10n/l10n.js"></script>
     <script>
-      html10n.quiet = true;
+      window.html10n.quiet = true;
     </script>
     <link rel="localizations" href="../i18n.json"
           type="application/l10n+json"/>


### PR DESCRIPTION
Remove the one in the not-quite-right place.

Fixes #652.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/653?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/653'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>