### PR TITLE
Make finishDeviceReady do work after it's called twice = readyFinisher.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -116,6 +116,7 @@ module.exports = function(grunt) {
           'src/helpers/Migrator.js',
           'src/helpers/multilingualchars.js',
           'src/helpers/basicauth.js',
+          'src/helpers/readyFinisher.js',
           'src/helpers/bindmine.js',
           'src/helpers/customStrings.js',
           'src/helpers/localizer.js',

--- a/src/app.js
+++ b/src/app.js
@@ -30,7 +30,8 @@
     config: window.spiderOakMobile_config,     // Supplemented in initialize.
     ready: function() {
       // Start listening for important app-level events
-      window.localizer.prepareHtml10n(window.spiderOakApp.readyFinisher);
+      window.localizer.prepareHtml10n(function () {
+        window.spiderOakApp.readyFinisher("localized");});
       document.addEventListener("deviceready", this.onDeviceReady, false);
       document.addEventListener("versionready", this.onVersionReady, false);
       document.addEventListener("loginSuccess", this.onLoginSuccess, false);
@@ -311,20 +312,14 @@
       );
     },
     backDisabled: true,
-    /** readyFinisher does actual work when called enough times: twice. */
-    readyFinisher: function() {
-      var numCalled = 0,
-          enoughCalled = 2;
-      function oneReady() {
-        numCalled += 1;
-        if (numCalled >= enoughCalled) {
-          window.spiderOakApp.brandSpecificInitialization();
-          window.spiderOakApp.initialize();
-          spiderOakApp.fileViewer = window.FileViewerPlugin;
-        }
+    readyFinisher: window.readyFinisher(
+      ["localized", "device"],
+      function() {
+        window.spiderOakApp.brandSpecificInitialization();
+        window.spiderOakApp.initialize();
+        spiderOakApp.fileViewer = window.FileViewerPlugin;
       }
-      return oneReady;
-    }(),
+    ),
     onDeviceReady: function() {
       $(document).on("backbutton", spiderOakApp.onBackKeyDown);
       $(document).on("menubutton", spiderOakApp.onMenuKeyDown);
@@ -333,12 +328,12 @@
       }
       if (window.cordovaHTTP) {
         window.cordovaHTTP.enableSSLPinning(true, function() {
-          window.spiderOakApp.readyFinisher();
+          window.spiderOakApp.readyFinisher("device");
         }, function() {
           console.log('Error. Enabling cert pinning failed');
         });
       } else {
-        window.spiderOakApp.readyFinisher();
+        window.spiderOakApp.readyFinisher("device");
       }
     },
     onVersionReady: function () {

--- a/src/app.js
+++ b/src/app.js
@@ -30,7 +30,7 @@
     config: window.spiderOakMobile_config,     // Supplemented in initialize.
     ready: function() {
       // Start listening for important app-level events
-      window.localizer.prepareHtml10n();
+      window.localizer.prepareHtml10n(window.spiderOakApp.readyFinisher);
       document.addEventListener("deviceready", this.onDeviceReady, false);
       document.addEventListener("versionready", this.onVersionReady, false);
       document.addEventListener("loginSuccess", this.onLoginSuccess, false);
@@ -311,11 +311,20 @@
       );
     },
     backDisabled: true,
-    finishDeviceReady: function() {
-      window.spiderOakApp.brandSpecificInitialization();
-      window.spiderOakApp.initialize();
-      spiderOakApp.fileViewer = window.FileViewerPlugin;
-    },
+    /** readyFinisher does actual work when called enough times: twice. */
+    readyFinisher: function() {
+      var numCalled = 0,
+          enoughCalled = 2;
+      function oneReady() {
+        numCalled += 1;
+        if (numCalled >= enoughCalled) {
+          window.spiderOakApp.brandSpecificInitialization();
+          window.spiderOakApp.initialize();
+          spiderOakApp.fileViewer = window.FileViewerPlugin;
+        }
+      }
+      return oneReady;
+    }(),
     onDeviceReady: function() {
       $(document).on("backbutton", spiderOakApp.onBackKeyDown);
       $(document).on("menubutton", spiderOakApp.onMenuKeyDown);
@@ -324,12 +333,12 @@
       }
       if (window.cordovaHTTP) {
         window.cordovaHTTP.enableSSLPinning(true, function() {
-          window.spiderOakApp.finishDeviceReady();
+          window.spiderOakApp.readyFinisher();
         }, function() {
           console.log('Error. Enabling cert pinning failed');
         });
       } else {
-        window.spiderOakApp.finishDeviceReady();
+        window.spiderOakApp.readyFinisher();
       }
     },
     onVersionReady: function () {

--- a/src/helpers/localizer.js
+++ b/src/helpers/localizer.js
@@ -18,7 +18,7 @@
        * 4. Omit empty entries.
        * 5. Include en-us fallback entry as last item, for no empty slots.
        */
-      prepareHtml10n: function () {
+      prepareHtml10n: function (success) {
         // Adapted from https://github.com/mclear/NFC_Ring_Control/blob/df8db31dd1683b04422c106a1484637629b4c88f/www/js/nfcRing/ui.js#L125-L135
 
         var candidates = [navigator.language, navigator.userLanguage,
@@ -52,6 +52,9 @@
           moment.locale([html10n.language]);
           document.documentElement.lang = html10n.getLanguage();
           document.documentElement.dir = html10n.getDirection();
+          if (success) {
+            success();
+          }
         });
       }
     };

--- a/src/helpers/readyFinisher.js
+++ b/src/helpers/readyFinisher.js
@@ -1,0 +1,41 @@
+(function (window, undefined) {
+  "use strict";
+  var console = window.console || {};
+  console.log = console.log || function(){};
+  var Backbone    = window.Backbone,
+      _           = window._,
+      $           = window.$;
+
+  /** Return a function that runs something when contingencies are satisfied.
+   *
+   * Contingencies are satisfied by repeatedly calling the returned function
+   * with each of the contingencies, separately, as arguments.
+   *
+   * An error is thrown if the function is called with unspecified
+   * contingencies, and a message is logged to console if the function is
+   * called repeatedly with the same contingency.
+   *
+   * @param {array} contingencies are strings naming what's pending.
+   * @param {object} finisherFunc, called when all contingencies are satisfied.
+   */
+  window.readyFinisher = function (contingencies, finisherFunc) {
+    var contingentsObj = {};
+    contingencies.forEach(function(item) { contingentsObj[item] = false; });
+    return function(which) {
+      if (! contingentsObj.hasOwnProperty(which)) {
+        throw new Error("No such finisher(" + which + ") contingency.");
+      } else {
+        if (contingentsObj[which]) {
+          console.log("Repeated finisher(" + which + ")");
+        }
+        contingentsObj[which] = true;
+        // We're ready if all contingents are true:
+        if (-1 == _.map(contingentsObj,
+                        function(value) {return value;}).indexOf(false)) {
+          finisherFunc();
+        }
+      }
+    };
+  };
+
+})(window);

--- a/src/views/PreliminaryView.js
+++ b/src/views/PreliminaryView.js
@@ -27,7 +27,7 @@
         window.tmpl['preliminaryViewTemplate']({})
       );
       $(".learn-more").html(
-        qq("Learn more about [[SpiderOak]]&raquo;",
+        qq("Learn more about [[SpiderOak]] &raquo;",
            {SpiderOak: s("SpiderOak")})
       );
       return this;

--- a/tests/index.js
+++ b/tests/index.js
@@ -271,6 +271,7 @@ describe('Application setup', function() {
         this.hardBoiledEggs("eggs");
         this.finishedSpy.should.not.have.been.called;
         this.consoleStub.should.have.been.called.once;
+        this.consoleStub.restore();
       });
       it('should throw an error on unspecified contingencies', function() {
         this.hardBoiledEggs("eggs");

--- a/tests/index.js
+++ b/tests/index.js
@@ -265,13 +265,13 @@ describe('Application setup', function() {
         this.finishedSpy.should.have.been.called.once;
       });
       it('should log a warning when contingencies are repeated', function() {
-        this.consoleStub = sinon.stub(console, "log");
         //this.consoleMock.expects("log");
         this.hardBoiledEggs("eggs");
+        this.consoleStub = sinon.stub(console, "log");
         this.hardBoiledEggs("eggs");
-        this.finishedSpy.should.not.have.been.called;
         this.consoleStub.should.have.been.called.once;
         this.consoleStub.restore();
+        this.finishedSpy.should.not.have.been.called;
       });
       it('should throw an error on unspecified contingencies', function() {
         this.hardBoiledEggs("eggs");

--- a/tests/index.js
+++ b/tests/index.js
@@ -240,6 +240,49 @@ describe('Application setup', function() {
            );
          });
     });
+    describe('readyFinisher', function() {
+      beforeEach(function(){
+        this.finishedSpy = sinon.spy();
+        this.contingencies = ["eggs", "water", "heat"];
+        this.hardBoiledEggs = window.readyFinisher(this.contingencies,
+                                                   this.finishedSpy);
+      });
+      it('should not run finishFunc before contingencies are satisfied',
+         function() {
+           this.finishedSpy.should.not.have.been.called;
+           this.hardBoiledEggs("eggs");
+           this.finishedSpy.should.not.have.been.called;
+           this.hardBoiledEggs("water");
+           this.finishedSpy.should.not.have.been.called;
+         }
+        );
+      it('should run finishFunc when contingencies are satisfied', function() {
+        this.finishedSpy.should.not.have.been.called;
+        var _this = this;
+        this.contingencies.forEach(function (which) {
+          _this.hardBoiledEggs(which);
+        });
+        this.finishedSpy.should.have.been.called.once;
+      });
+      it('should log a warning when contingencies are repeated', function() {
+        this.consoleStub = sinon.stub(console, "log");
+        //this.consoleMock.expects("log");
+        this.hardBoiledEggs("eggs");
+        this.hardBoiledEggs("eggs");
+        this.finishedSpy.should.not.have.been.called;
+        this.consoleStub.should.have.been.called.once;
+      });
+      it('should throw an error on unspecified contingencies', function() {
+        this.hardBoiledEggs("eggs");
+        var gotError;
+        try {
+          this.hardBoiledEggs("spam");
+        } catch (e) {
+          gotError = e;
+        }
+        chai.expect(gotError).is.instanceof(Error);
+      });
+    });
   });
 
 });

--- a/tpl/aboutSpiderOakViewTemplate.html
+++ b/tpl/aboutSpiderOakViewTemplate.html
@@ -17,7 +17,7 @@
     </p>
     {{?}}
     <p>
-      <span>{{= qq("Thank you for using [[SpiderOak]] and please don't hesitate to send comments or questions to",
+      <span>{{= qq("Thank you for using [[SpiderOak]] and please don’t hesitate to send comments or questions to",
         {"SpiderOak": s("SpiderOak")})}}</span>
       <span> </span>
       <a href="#email-feedback" class="email-link">{{= it.platform }}@{{= s("spideroak.com") }}</a>.</p>


### PR DESCRIPTION
Fixes #659.

I've launched the iOS from a fresh install at least 10 times without seeing the problem occur once. I'm pretty confident this solves the problem.

(I've also launched the app on a fresh android install at least four times, three on emulator and once on nexus 7, with no problems. It runs fine in the security-inhibited browser, as well.)

(Two more successful times on iOS... (-: )
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/pull/660%23issuecomment-78441035%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/pull/660%23issuecomment-78441035%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22For%20the%20sake%20of%20comparison%2C%20I%27ve%20also%20implemented%20a%20Promise-based%20solution%2C%20in%20the%20%5Balternate-659-promise-init%20branch%5D%28https%3A//github.com/SpiderOak/SpiderOakMobileClient/tree/alternate-659-promise-init%29.%20It%27s%20a%20much%20more%20generic%20solution%2C%20but%20also%20involves%20more%20clutter%20for%20this%20simple%20case.%5Cr%5Cn%5Cr%5Cn%28%27grunt%20yolo%3A...%27%20is%20necessary%2C%20the%20console%20tests%20choke%20on%20bluebird%20Promise%2C%20but%20running%20the%20tests%20in%20the%20browser%20works%20fine...%29%22%2C%20%22created_at%22%3A%20%222015-03-12T08%3A35%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/515685%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kenmanheimer%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/660#issuecomment-78441035'>General Comment</a></b>
- <a href='https://github.com/kenmanheimer'><img border=0 src='https://avatars.githubusercontent.com/u/515685?v=3' height=16 width=16'></a> For the sake of comparison, I've also implemented a Promise-based solution, in the [alternate-659-promise-init branch](https://github.com/SpiderOak/SpiderOakMobileClient/tree/alternate-659-promise-init). It's a much more generic solution, but also involves more clutter for this simple case.
('grunt yolo:...' is necessary, the console tests choke on bluebird Promise, but running the tests in the browser works fine...)


<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/660?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/660?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/660'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>