### PR TITLE
Alternate 659 promise init

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -245,6 +245,12 @@ module.exports = function(grunt) {
         ],
         dest: 'www/components/store.js/store.min.js'
       },
+      promise: {
+        src: [
+          'bower_components/bluebird/js/browser/bluebird.js'
+        ],
+        dest: 'www/components/bluebird/bluebird.js'
+      },
       semver: {
         src: [
           'node_modules/semver/semver.browser.js'

--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,7 @@
     "Nibbler.min": "http://www.tumuski.com/library/Nibbler/Nibbler.js",
     "zepto": "https://github.com/madrobby/zepto/archive/v1.1.0.zip",
     "iscroll": "https://github.com/cubiq/iscroll/archive/v4.2.zip",
+    "bluebird": "2.9.14",
     "modernizr": "2.6.3",
     "moment": "~2.8.0",
     "html10n": "https://github.com/SpiderOak/html10n.js.git#spideroak",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "grunt-xliff": "git://github.com/alex-seville/grunt-xliff.git#79d632671a",
     "mocha": "~1.8.1",
     "chai": "~1.8.0",
+    "chai-as-promised": "~4.3.0",
     "sinon": "~1.7.3",
     "sinon-chai": "~2.4.0",
     "chai-jquery": "~1.1.2",

--- a/src/app.js
+++ b/src/app.js
@@ -39,7 +39,6 @@
           localizeFinish = new Promise(function (resolve, reject) {
             localizeFinishResolver = resolve;
           }),
-          allFinishResolver,
           allFinish = Promise.all([readyFinish, localizeFinish]);
       allFinish.then(soApp.finishDeviceReady);
       window.localizer.prepareHtml10n(localizeFinishResolver);

--- a/src/app.js
+++ b/src/app.js
@@ -30,18 +30,18 @@
   _.extend(spiderOakApp, {
     config: window.spiderOakMobile_config,     // Supplemented in initialize.
     ready: function() {
-      // Start listening for important app-level events
       var soApp = window.spiderOakApp,
           readyFinish = new Promise(function (resolve, reject) {
-            soApp.readyFinishResolver = resolve;
+            // Resolve with explicit value for tests and debugging clarity.
+            soApp.readyFinishResolver = function() {resolve("readyFinish");};
           }),
-          localizeFinishResolver,
           localizeFinish = new Promise(function (resolve, reject) {
-            localizeFinishResolver = resolve;
-          }),
-          allFinish = Promise.all([readyFinish, localizeFinish]);
-      allFinish.then(soApp.finishDeviceReady);
-      window.localizer.prepareHtml10n(localizeFinishResolver);
+            soApp.localizeFinishResolver = function() {resolve("localized");};
+          });
+      soApp.allFinish = Promise.all([readyFinish, localizeFinish]);
+      soApp.allFinish.then(function () {soApp.finishDeviceReady();});
+      window.localizer.prepareHtml10n(soApp.localizeFinishResolver);
+      // Start listening for important app-level events
       document.addEventListener("deviceready", this.onDeviceReady, false);
       document.addEventListener("versionready", this.onVersionReady, false);
       document.addEventListener("loginSuccess", this.onLoginSuccess, false);

--- a/src/app.js
+++ b/src/app.js
@@ -29,19 +29,20 @@
 
   _.extend(spiderOakApp, {
     config: window.spiderOakMobile_config,     // Supplemented in initialize.
-    readyFinish: new Promise(function (resolve, reject) {
-      window.readyFinishResolver = resolve;
-    }),
-    localizeFinish: new Promise(function (resolve, reject) {
-      window.localizeFinishResolver = resolve;
-    }),
     ready: function() {
       // Start listening for important app-level events
       var soApp = window.spiderOakApp,
+          readyFinish = new Promise(function (resolve, reject) {
+            soApp.readyFinishResolver = resolve;
+          }),
+          localizeFinishResolver,
+          localizeFinish = new Promise(function (resolve, reject) {
+            localizeFinishResolver = resolve;
+          }),
           allFinishResolver,
-          allFinish = Promise.all([soApp.readyFinish, soApp.localizeFinish]);
+          allFinish = Promise.all([readyFinish, localizeFinish]);
       allFinish.then(soApp.finishDeviceReady);
-      window.localizer.prepareHtml10n(window.localizeFinishResolver);
+      window.localizer.prepareHtml10n(localizeFinishResolver);
       document.addEventListener("deviceready", this.onDeviceReady, false);
       document.addEventListener("versionready", this.onVersionReady, false);
       document.addEventListener("loginSuccess", this.onLoginSuccess, false);
@@ -336,13 +337,13 @@
       if (window.cordovaHTTP) {
         window.cordovaHTTP.enableSSLPinning(true, function() {
           //window.spiderOakApp.finishDeviceReady();
-          window.readyFinishResolver();
+          window.spiderOakApp.readyFinishResolver();
         }, function() {
           console.log('Error. Enabling cert pinning failed');
         });
       } else {
         //window.spiderOakApp.finishDeviceReady();
-        window.readyFinishResolver();
+        window.spiderOakApp.readyFinishResolver();
       }
     },
     onVersionReady: function () {

--- a/src/helpers/localizer.js
+++ b/src/helpers/localizer.js
@@ -18,7 +18,7 @@
        * 4. Omit empty entries.
        * 5. Include en-us fallback entry as last item, for no empty slots.
        */
-      prepareHtml10n: function () {
+      prepareHtml10n: function (success) {
         // Adapted from https://github.com/mclear/NFC_Ring_Control/blob/df8db31dd1683b04422c106a1484637629b4c88f/www/js/nfcRing/ui.js#L125-L135
 
         var candidates = [navigator.language, navigator.userLanguage,
@@ -52,6 +52,9 @@
           moment.locale([html10n.language]);
           document.documentElement.lang = html10n.getLanguage();
           document.documentElement.dir = html10n.getDirection();
+          if (success) {
+            success();
+          }
         });
       }
     };

--- a/tests/index.js
+++ b/tests/index.js
@@ -86,43 +86,26 @@ describe('Application setup', function() {
       /* This is actually two tests, combined because i haven't unraveled
        * how to re-initialize the app.
        *
-       * The prominent contrary cases fail in distinct, illuminating ways:
+       * Contrary cases failure modes are illuminating:
+       *
+       * - if window.spiderOakApp.localizeFinishResolver() is not fired, the
+       *   test fails with a timeout.
        * - "...should.not.eventually.be.fulfilled..." error report shows
        *   the actual resolution values of allFinish' sub-promises.
-       * - not firing soApp.localizeFinishResolver() fails on a timeout.
        */
-      var soApp = window.spiderOakApp,
-          allFinish = soApp.allFinish,
-          fDRStub = sinon.stub(soApp, "finishDeviceReady");
-      soApp.allFinish.then(function() {
+      var fDRStub = sinon.stub(window.spiderOakApp, "finishDeviceReady");
+      window.spiderOakApp.allFinish.then(function() {
         fDRStub.should.have.been.called.once;
         fDRStub.restore();
       });
-      if (! soApp.localizeFinishResolver) {
+      if (! window.spiderOakApp.localizeFinishResolver) {
         // Reduce unfortunate sensitivity to whether or not done elsewhere.
-        soApp.ready();
+        window.spiderOakApp.ready();
       }
-      // (soApp.readyFinishResolver() already done in app init.)
-      soApp.localizeFinishResolver();
-      allFinish.should.eventually.be.fulfilled.and.notify(done);
-      // '...and.notify(done)' because our version of mocha apparently
-      // isn't promise-friently.
-    });
-    it('resolving subfinishers should fulfill allFinish', function(done) {
-      /* The prominent contrary cases fail in distinct, illuminating ways:
-       * - "...should.not.eventually.be.fulfilled..." error report shows
-       *   the actual resolution values of allFinish' sub-promises.
-       * - not firing soApp.localizeFinishResolver() fails on a timeout.
-       */
-      var soApp = window.spiderOakApp,
-          allFinish = soApp.allFinish;
-      if (! soApp.localizeFinishResolver) {
-        // Reduce unfortunate sensitivity to whether or not done elsewhere.
-        soApp.ready();
-      }
-      // (soApp.readyFinishResolver() already done in app init.)
-      soApp.localizeFinishResolver();
-      allFinish.should.eventually.be.fulfilled.and.notify(done);
+      // (window.spiderOakApp.readyFinishResolver() already done in app init.)
+      window.spiderOakApp.localizeFinishResolver();
+      window.spiderOakApp.allFinish.should.eventually.be.fulfilled
+        .and.notify(done);
       // '...and.notify(done)' because our version of mocha apparently
       // isn't promise-friently.
     });

--- a/tests/index.js
+++ b/tests/index.js
@@ -82,6 +82,50 @@ describe('Application setup', function() {
       helper.trigger(window.document,'deviceready');
       window.spiderOakApp.onDeviceReady.called.should.equal(true);
     });
+    it('resolving subfinishers should fulfill allFinish', function(done) {
+      /* This is actually two tests, combined because i haven't unraveled
+       * how to re-initialize the app.
+       *
+       * The prominent contrary cases fail in distinct, illuminating ways:
+       * - "...should.not.eventually.be.fulfilled..." error report shows
+       *   the actual resolution values of allFinish' sub-promises.
+       * - not firing soApp.localizeFinishResolver() fails on a timeout.
+       */
+      var soApp = window.spiderOakApp,
+          allFinish = soApp.allFinish,
+          fDRStub = sinon.stub(soApp, "finishDeviceReady");
+      soApp.allFinish.then(function() {
+        fDRStub.should.have.been.called.once;
+        fDRStub.restore();
+      });
+      if (! soApp.localizeFinishResolver) {
+        // Reduce unfortunate sensitivity to whether or not done elsewhere.
+        soApp.ready();
+      }
+      // (soApp.readyFinishResolver() already done in app init.)
+      soApp.localizeFinishResolver();
+      allFinish.should.eventually.be.fulfilled.and.notify(done);
+      // '...and.notify(done)' because our version of mocha apparently
+      // isn't promise-friently.
+    });
+    it('resolving subfinishers should fulfill allFinish', function(done) {
+      /* The prominent contrary cases fail in distinct, illuminating ways:
+       * - "...should.not.eventually.be.fulfilled..." error report shows
+       *   the actual resolution values of allFinish' sub-promises.
+       * - not firing soApp.localizeFinishResolver() fails on a timeout.
+       */
+      var soApp = window.spiderOakApp,
+          allFinish = soApp.allFinish;
+      if (! soApp.localizeFinishResolver) {
+        // Reduce unfortunate sensitivity to whether or not done elsewhere.
+        soApp.ready();
+      }
+      // (soApp.readyFinishResolver() already done in app init.)
+      soApp.localizeFinishResolver();
+      allFinish.should.eventually.be.fulfilled.and.notify(done);
+      // '...and.notify(done)' because our version of mocha apparently
+      // isn't promise-friently.
+    });
   });
 
   describe('spiderOakApp.ajax', function() {

--- a/www/index.html
+++ b/www/index.html
@@ -78,6 +78,7 @@
     <script src="components/modernizr/modernizr.js"></script>
     <script src="components/modernizr/feature-detects/css-overflow-scrolling.js"></script>
     <script src="components/store.js/store.min.js"></script>
+    <script src="components/bluebird/bluebird.js"></script>
     <script src="components/semver/semver.browser.js"></script>
     <script src="components/moment/moment.js"></script>
     <script src="components/html10n/l10n.js"></script>

--- a/www/tests/index.html
+++ b/www/tests/index.html
@@ -36,6 +36,7 @@
     <script src="../components/modernizr/modernizr.js"></script>
     <script src="../components/modernizr/feature-detects/css-overflow-scrolling.js"></script>
     <script src="../components/store.js/store.min.js"></script>
+    <script src="../components/bluebird/bluebird.js"></script>
     <script src="../components/semver/semver.browser.js"></script>
     <script src="../components/moment/moment.js"></script>
     <script src="../components/html10n/l10n.js"></script>

--- a/www/tests/index.html
+++ b/www/tests/index.html
@@ -16,6 +16,7 @@
     <!-- Testing apparatus -->
     <script src="../../node_modules/mocha/mocha.js"></script>
     <script src="../../node_modules/chai/chai.js"></script>
+    <script src="../../node_modules/chai-as-promised/lib/chai-as-promised.js"></script>
     <!-- Sinon.JS - might need more individual libs -->
     <script src="../../node_modules/sinon/lib/sinon.js"></script>
     <script src="../../node_modules/sinon/lib/sinon/spy.js"></script>


### PR DESCRIPTION
Fixes #659, providing  coordinationg of asynchronous app init activities, to ensure that localization concludes before finishDeviceReady fires.

This is a promise-based alternative to the custom function implemented in #660. It includes a test, and offers some value not just in implementing the solution in relatively few lines, but also some value in hooking promises, and testing of promises, to in to our app.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/pull/662%23issuecomment-80713472%22%2C%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/pull/662%23discussion_r26443352%22%2C%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/pull/662%23discussion_r26444902%22%2C%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/pull/662%23discussion_r26449380%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/pull/662%23issuecomment-80713472%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%28I%20think%20the%20duplicate%2C%20constituent%20commits%20are%20because%20I%20rebased%20on%20master%2C%20to%20ensure%20that%20localization%20fixes%20there%20correct%20for%20some%20errors%20that%27ll%20show%20in%20testing%20this.%29%22%2C%20%22created_at%22%3A%20%222015-03-14T20%3A40%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/515685%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kenmanheimer%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%206ed5f19f5d2620c3b6cc15cf49e2fd72a06cefdc%20src/app.js%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/pull/662%23discussion_r26443352%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20the%20variable%20abstraction%20needed%3F%20Or%20is%20it%20just%20so%20it%27s%20shorter%3F%22%2C%20%22created_at%22%3A%20%222015-03-15T00%3A36%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/554999%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/devgeeks%22%7D%7D%2C%20%7B%22body%22%3A%20%22Just%20to%20be%20shorter.%20Not%20crucial%2C%20could%20be%20removed.%5Cr%5Cn%5Cr%5Cn%28I%20had%20originally%20included%20a%20commented-out%20line%20for%20revealing%20functionality%2C%20and%20needed%20to%20shorten%20it%20so%20it%20only%20took%20one%20line.%20%29%22%2C%20%22created_at%22%3A%20%222015-03-15T06%3A22%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/515685%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kenmanheimer%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20committed%20a%20change%20to%20use%20window.spiderOakApp%20instead%20of%20soApp%2C%20to%20be%20more%20explicit%20and%20more%20like%20other%20tests.%22%2C%20%22created_at%22%3A%20%222015-03-15T16%3A53%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/515685%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kenmanheimer%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/app.js%3AL30-48%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/662#issuecomment-80713472'>General Comment</a></b>
- <a href='https://github.com/kenmanheimer'><img border=0 src='https://avatars.githubusercontent.com/u/515685?v=3' height=16 width=16'></a> (I think the duplicate, constituent commits are because I rebased on master, to ensure that localization fixes there correct for some errors that'll show in testing this.)
- [ ] <a href='#crh-comment-Pull 6ed5f19f5d2620c3b6cc15cf49e2fd72a06cefdc src/app.js 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/662#discussion_r26443352'>File: src/app.js:L30-48</a></b>
- <a href='https://github.com/devgeeks'><img border=0 src='https://avatars.githubusercontent.com/u/554999?v=3' height=16 width=16'></a> Is the variable abstraction needed? Or is it just so it's shorter?
- <a href='https://github.com/kenmanheimer'><img border=0 src='https://avatars.githubusercontent.com/u/515685?v=3' height=16 width=16'></a> Just to be shorter. Not crucial, could be removed.
(I had originally included a commented-out line for revealing functionality, and needed to shorten it so it only took one line. )
- <a href='https://github.com/kenmanheimer'><img border=0 src='https://avatars.githubusercontent.com/u/515685?v=3' height=16 width=16'></a> I committed a change to use window.spiderOakApp instead of soApp, to be more explicit and more like other tests.


<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/662?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/662?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/662'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>