### PR TITLE
Revert "Issue 644 login sans browse url"

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -192,7 +192,8 @@ module.exports = function(grunt) {
           'bower_components/zepto/src/polyfill.js',
           'bower_components/zepto/src/selector.js',
           'bower_components/zepto/src/stack.js',
-          'bower_components/zepto/src/touch.js'
+          'bower_components/zepto/src/touch.js',
+          'bower_components/zepto/src/ie.js'
         ],
         dest: 'www/components/zepto/zepto.js'
       },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -192,8 +192,7 @@ module.exports = function(grunt) {
           'bower_components/zepto/src/polyfill.js',
           'bower_components/zepto/src/selector.js',
           'bower_components/zepto/src/stack.js',
-          'bower_components/zepto/src/touch.js',
-          'bower_components/zepto/src/ie.js'
+          'bower_components/zepto/src/touch.js'
         ],
         dest: 'www/components/zepto/zepto.js'
       },

--- a/src/models/AccountModel.js
+++ b/src/models/AccountModel.js
@@ -15,9 +15,12 @@
   spiderOakApp.AccountModel = spiderOakApp.ModelBase.extend({
     defaults: {
       rememberme: false,
+      data_center_regex: /(https:\/\/[^\/]+)\//m,
       response_parse_regex: /^(login|location):(.+)$/m,
+      storage_web_url: "",      // Irrelevant to mobile client for now.
 
       state: false,
+      interrupting: false,
       loginname: "",
       b32username: "",
       basicAuthCredentials: "",
@@ -49,6 +52,8 @@
      *
      * @returns (boolean) false: not logged in
      * @returns (boolean) true: logged in
+     * @returns (string) "in-process": login dance is happening
+     * @returns (string) "interrupting": login dance is being interrupted
      *
      * @see setState
      */
@@ -67,6 +72,24 @@
       this.setLoginState(true);
       if (this.passcodeWasBypassed()) {
         this.passcodeWasBypassedFollowup();
+      }
+    },
+    doInterruption: function() {
+      var status = this.getLoginState();
+      if (status === true) {
+        // logged in - logout, clearing stuff in the process:
+        this.logout();
+        return "interrupting";
+      }
+      else if ((status === "in-process") || (status === "interrupting")) {
+        // Not actually logged in, just clear stuff:
+        this.loggedOut();
+        return "interrupting";
+      }
+      else {
+        console.log("AccountModel.login(): unexpected interruption state");
+        this.loggedOut();
+        return "interrupting";
       }
     },
 
@@ -184,11 +207,6 @@
       return which + "_" + this.get("b32username");
     },
 
-    loginUrl: function(server, username) {
-      return ("https://" + server + "/storage/" +
-              spiderOakApp.b32nibbler.encode(username) +
-              "/login");
-    },
     /** Storage login.
      * https://spideroak.com/faq/questions/37/how_do_i_use_the_spideroak_web_api
      *
@@ -199,9 +217,12 @@
      * @param {string} successCallback - gets data, status code, xhr
      * @param {string} errorCallback - gets status code, status text, xhr
      * @param {string} login_url Optional explicit login location
+     * @param {string} probeHost Optional explicit login domain, for trial that will not have actual login effect
      */
     login: function(username, password, successCallback, errorCallback,
-                    login_url) {
+                    login_url, probeHost) {
+      var ajax = probeHost ? spiderOakApp.dollarAjax : spiderOakApp.ajax;
+
       /* @TODO: Move the notification to a view element, probably LoginView. */
       if (!spiderOakApp.networkAvailable && navigator.notification) {
         navigator.notification.confirm(
@@ -211,19 +232,24 @@
           qq("OK")
         );
         spiderOakApp.dialogView.hide();
-        return null;
+        return;
+      }
+
+      if (this.getLoginState() === "interrupting") {
+        return this.doInterruption();
+      }
+      else if (! probeHost) {
+        this.setLoginState("in-process");
       }
 
       var _self = this,
-          server = spiderOakApp.settings.getValue("server"),
-          login_url_start = _self.loginUrl(server, username);
-
-      if (! login_url) {
-        login_url = login_url_start;
-      }                         // ... otherwise use already-set login_url.
+          server = (probeHost ||
+                    spiderOakApp.settings.getValue("server")),
+          login_url_start = "https://" + server + "/browse/login";
+      login_url = login_url || login_url_start;
 
 
-      spiderOakApp.ajax({
+      ajax({
         type: "POST",
         url: login_url,
         cache: false,
@@ -235,81 +261,124 @@
           password: password
         },
 
+        /** Handle server login success. */
         success: function(data, status, xhr) {
           var where = data.match(_self.get("response_parse_regex"));
 
-          if (where && where[1] === "location") {
-            return _self.loginSuccess(login_url_start,
-                                      server, username, password,
-                                      data.slice("location:".length),
-                                      successCallback);
+          /** Register settings according to a successful login.
+           *
+           * @param {string} login_url - the actual login location. Eg:
+           *        https://web-dc2.spideroak.com/storage/EBRG6Z3VOMQA/login
+           * @param {string} locationResponse - the account's web browsing URL
+           */
+          function loginSuccess(login_url, locationResponse) {
+            var splat = login_url.split('/');
+            var b32username = splat[splat.length - 2];
+            var gotUsername = spiderOakApp.b32nibbler.decode(b32username);
+            var storageHost = splat.slice(0, splat.length-3).join("/");
+            var storageRootURL = storageHost + "/storage/" + b32username + "/";
+
+            _self.set("login_url_preface", "https://" + server + "/storage/");
+            _self.set("login_url_start", "https://" + server + "/browse/login");
+            _self.set("logout_url_preface", "https://" + server + "/storage/");
+
+            // The name by which they logged in.  (For Blue/enterprise
+            // users, it's different than b32decode(b32username.)
+            _self.set("loginname", username);
+            // The base32 encrypted version of the internal username used
+            // on the login and content urls.
+            _self.set("b32username",b32username);
+            // @TODO: Set the keychain credentials
+            // Set the basicauth details:
+            _self.basicAuthManager.setAccountBasicAuth(username, password);
+            // Record the basic auth credentials
+            _self.set("basicAuthCredentials",
+                      _self.basicAuthManager.getAccountBasicAuth());
+            // Record the login url:
+            _self.set("login_url", login_url);
+            // Record the root of the account's storage content:
+            _self.set("storageRootURL", storageRootURL);
+            // Record the location of the account's shares list:
+            _self.set("mySharesListURL", storageRootURL + "shares");
+            // Record the location of the account's shares root:
+            _self.set("mySharesRootURL", storageHost + "/share/");
+            // Record the web browsing root location:
+            _self.set("webRootURL", locationResponse);
+            // Return the data center part of the url:
+            var dc = login_url.match(_self.get("data_center_regex"))[1];
+            // Trigger the login complete event so other views can react
+            _self.loggedIn();
+            $(document).trigger('loginSuccess');
+            successCallback(dc + "/");
+          }
+
+
+          if (where && where[1] === "login") {
+            // Try again at indicated data center and/or path:
+            if (where[2].charAt(0) === "/") {
+              // Revise just the path part of the login url:
+              login_url = login_url.match(
+                _self.get("data_center_regex"))[1] + where[2];
+            }
+            else {
+              // Use the new login url, wholesale:
+              login_url = where[2];
+            }
+            // Recurse, with adjusted login_url:
+            if ((_self.login(username, password,
+                             successCallback, errorCallback,
+                             login_url, probeHost) === "interrupting") &&
+                errorCallback) {
+              errorCallback(0, "interrupted", xhr);
+            }
+          }
+          else if (where && where[1] === "location") {
+            var destination = login_url;
+            if (destination === login_url_start) {
+              destination = where[2];
+            }
+            if (! probeHost) {
+              loginSuccess(destination, data.slice("location:".length));
+            }
           }
           else {
             if (username === "") {
-              return errorCallback(403, "Authentication failed", xhr);
+              errorCallback(403, "Authentication failed", xhr);
             }
             else {
-              return errorCallback(0, "unexpected server response", xhr);
+              errorCallback(0, "unexpected server response", xhr);
             }
           }
         },
         error: function(xhr, errorType, error) {
-          _self.setLoginState(false);
-          return errorCallback(xhr.status, "authentication failed", xhr);
+          if (! probeHost) {
+            _self.setLoginState(false);
+          }
+          errorCallback(xhr.status, "authentication failed", xhr);
         }
       });
-      return null;
     },
 
-    /** Register settings according to a successful login.
+    /** Interrupt in-process login, or logout if logged in.
      *
-     * @param {string} login_url - the actual login location. Eg:
-     *        https://web-dc2.spideroak.com/storage/EBRG6Z3VOMQA/login
-     * @param {string} username
-     * @param {string} password
-     * @param {string} locationResponse - the account's web browsing URL
-     * @param {string} successCallback
+     * @return (boolean) true if login is in process, or was logged-in.
      */
-    loginSuccess: function(login_url, server, username, password,
-                           locationResponse,
-                           successCallback) {
-      var splat = login_url.split('/');
-      var b32username = splat[splat.length - 2];
-      var gotUsername = spiderOakApp.b32nibbler.decode(b32username);
-      var storageHost = splat.slice(0,3).join("/");
-      var storageRootURL = storageHost + "/storage/" + b32username + "/";
-
-      this.set("login_url_preface", "https://" + server + "/storage/");
-      this.set("login_url_start", this.loginUrl(server, gotUsername));
-      this.set("logout_url_preface", "https://" + server + "/storage/");
-
-      // The name by which they logged in.  (For Blue/enterprise
-      // users, it's different than b32decode(b32username.)
-      this.set("loginname", username);
-      // The base32 encrypted version of the internal username used
-      // on the login and content urls.
-      this.set("b32username",b32username);
-      // @TODO: Set the keychain credentials
-      // Set the basicauth details:
-      this.basicAuthManager.setAccountBasicAuth(username, password);
-      // Record the basic auth credentials
-      this.set("basicAuthCredentials",
-                this.basicAuthManager.getAccountBasicAuth());
-      // Record the login url:
-      this.set("login_url", login_url);
-      // Record the root of the account's storage content:
-      this.set("storageRootURL", storageRootURL);
-      // Record the location of the account's shares list:
-      this.set("mySharesListURL", storageRootURL + "shares");
-      // Record the location of the account's shares root:
-      this.set("mySharesRootURL", storageHost + "/share/");
-      // Record the web browsing root location:
-      this.set("webRootURL", locationResponse);
-      // Return the data center part of the url:
-      // Trigger the login complete event so other views can react
-      this.loggedIn();
-      $(document).trigger('loginSuccess');
-      successCallback(storageHost + "/");
+    interruptLogin: function() {
+      var status = this.getLoginState();
+      if (status === "in-process") {
+        this.setLoginState("interrupting");
+        return true;
+      }
+      else if (status === "interrupting") {
+        return true;
+      }
+      else if (status === true) {
+        this.logout();
+        return true;
+      }
+      else {
+        return false;
+      }
     },
     /** Do server logout and local zeroing of credentials, etc.
      *

--- a/src/views/SettingsView.js
+++ b/src/views/SettingsView.js
@@ -428,21 +428,12 @@
           }
         };
 
-        spiderOakApp.dollarAjax(
-          {
-            type: "POST",
-            url: "https://" + newServer + "/browse/login",
-            cache: false,
-            data: {username: " ", password: ""},
-            headers: {"X-SpiderOak-Mobile-Client": "spideroak.com"},
-            success: function(statusCode, statusText, xhr) {
-              handleLoginProbeResult(statusCode, statusText, xhr);
-            },
-            error: function(xhr, statusCode, statusText) {
-              handleLoginProbeResult(statusCode, statusText, xhr);
-            }
-          }
-        );
+        // Do the right thing via a login probe of the new server address:
+        spiderOakApp.accountModel.login(" ", "",
+                                        handleLoginProbeResult,
+                                        handleLoginProbeResult,
+                                        null,
+                                        newServer);
       }
     },
     changeServerButton_tapHandler: function(event) {

--- a/tests/models/AccountModel.js
+++ b/tests/models/AccountModel.js
@@ -14,7 +14,7 @@ describe('AccountModel', function() {
       this.username = "testusername";
       this.b32username = window.spiderOakApp.b32nibbler.encode(this.username);
       this.password = "testpassword";
-      this.loginURL = "https://spideroak.com/storage/[A-Z0-9]+/login";
+      this.loginURL = "https://spideroak.com/browse/login";
       this.loginURLUnCached = RegExp(this.loginURL + "(\\?.*)?");
       this.loginAltURL = ("https://alternate-dc.spideroak.com/" +
                           this.b32username +
@@ -407,6 +407,161 @@ describe('AccountModel', function() {
     // @TODO Test unsuccessful server addr change - should not change anything
     // @TODO Test successful server addr change, sans current account
     // @TODO Test successful server change, with current account - logs out
+
+    describe('Server probe', function() {
+      beforeEach(function(){
+        this.dollarAjaxStub = sinon.stub(window.spiderOakApp, "dollarAjax");
+        this.mainAjaxStub = sinon.stub(window.spiderOakApp, "ajax");
+      });
+      afterEach(function() {
+        window.spiderOakApp.dollarAjax.restore();
+        window.spiderOakApp.ajax.restore();
+      });
+      it('Should use .dollarAjax for server probe, rather than .ajax',
+         function () {
+        this.accountModel.login(this.username, this.password,
+                                this.successSpy, this.errorSpy,
+                                this.login_url,
+                                "stub.probe.host");
+           this.dollarAjaxStub.should.have.been.called;
+           this.mainAjaxStub.should.not.have.been.called;
+         });
+      it('Should use .ajax for regular login, rather than .dollarAjax',
+         function () {
+           this.accountModel.login(this.username, this.password,
+                                   this.successSpy, this.errorSpy,
+                                   this.login_url);
+           this.dollarAjaxStub.should.not.have.been.called;
+           this.mainAjaxStub.should.have.been.called;
+         });
+    });
+    describe('successful alternate login', function() {
+      beforeEach(function(){
+        this.successSpy = sinon.spy();
+        this.errorSpy = sinon.spy();
+        this.server.respondWith(
+          "POST",
+          this.loginURLUnCached,
+          [200, {"Content-Type": "text/html"}, "login:" + this.loginAltURL]
+        );
+        this.server.respondWith(
+          "POST",
+          this.loginAltURLUnCached,
+          [
+            200,
+            {"Content-Type": "text/html"},
+            "location:/" + this.b32username + "/login"
+          ]
+        );
+        this.accountModel.login(this.username, this.password,
+                                this.successSpy, this.errorSpy);
+        this.server.respond();
+      });
+      it('should call the alternate server using POST', function() {
+        this.server.requests[1].method.should.equal("POST");
+      });
+      it('should call the alternate success callback', function() {
+        this.successSpy.should.have.been.calledOnce;
+        this.successSpy.should.have.been.calledWith(
+          "https://alternate-dc.spideroak.com/"
+        );
+      });
+      it('should set accountModel b32username upon successful alternate login',
+        function() {
+          this.accountModel.get("b32username").should.equal(this.b32username);
+        });
+    });
+
+    describe('interrupt in-process login', function() {
+      beforeEach(function(){
+        this.successSpy = sinon.spy();
+        this.errorSpy = sinon.spy();
+
+        /* In order to contrive for login interruptions at specific point
+         * in the recursive login process, we instrument the fakeServer
+         * responder so we can invoke login interruption at the key points.
+         */
+
+        /* Set this to URL on which responder will interrupt login process:
+         */
+        this.responderInterruptAfterURL = "set this to desired URL";
+        /* To affirm that login state is "in-process" while login is happening,
+           set .responderInterruptAfterURL === "test getLoginState" */
+        this.responderLoginState = [];
+        var responder = function (request) {
+          function accumulateLoginTestState() {
+            if (this.responderInterruptAfterURL === "test getLoginState") {
+              this.responderLoginState.push(this.accountModel.getLoginState());
+            };
+          }
+          if (request.url.match(RegExp(this.responderInterruptAfterURL +
+                                       "(.*)?"))) {
+            this.accountModel.interruptLogin();
+          }
+          if (request.url.match(this.loginURLUnCached)) {
+            accumulateLoginTestState();
+            request.respond(
+              200,
+              {"Content-Type": "text/html"},
+              "login:" + this.loginAltURL);
+          }
+          else if (request.url.match(this.loginAltURLUnCached)) {
+            accumulateLoginTestState();
+            request.respond(
+              200,
+              {"Content-Type": "text/html"},
+              this.loginLocation
+            );
+          }
+          // Provide for logout:
+          else if (request.url.match(
+            RegExp("https://spideroak.com/storage/" +
+                   this.b32username + "/logout(\\?.*)?"))) {
+            request.respond(
+              200, {"Content-Type": "text/html"}, "the response page"
+            );
+          }
+          else {
+            request.respond(
+              404,
+              {"Content-Type": "text/plain"},
+              'Not found'
+            );
+          }
+        }.bind(this);
+        this.server.respondWith(responder);
+      });
+      afterEach:(function() {
+        this.responderInterruptAfterURL = false;
+      });
+      it('non-interrupted login should work as usual', function() {
+        this.accountModel.getLoginState().should.equal(false);
+        this.accountModel.login(this.username, this.password,
+                                this.successSpy, this.errorSpy);
+        this.responderInterruptAfterURL = false;
+        this.server.respond();
+        this.accountModel.getLoginState().should.equal(true);
+      });
+      it('getLoginState() should be "in-process" during login', function() {
+        this.accountModel.getLoginState().should.equal(false);
+        this.accountModel.login(this.username, this.password,
+                                this.successSpy, this.errorSpy);
+        this.responderInterruptAfterURL = "test getLoginState";
+        this.server.respond();
+        this.responderLoginState.map(function (state) {
+          state.should.equal("in-process");
+        });
+      });
+      it('interrupting should work in the early login process', function() {
+        this.accountModel.getLoginState().should.equal(false);
+        this.accountModel.login(this.username, this.password,
+                                this.successSpy, this.errorSpy);
+        this.responderInterruptAfterURL = this.loginURL;
+        this.server.respond();
+        // We're doing a multi-stage login:
+        this.accountModel.getLoginState().should.equal(false);
+      });
+    });
 
     // rare but possible?
     describe('unsuccessful alternate login', function() {


### PR DESCRIPTION
Reverts SpiderOak/SpiderOakMobileClient#650

Fixes #669
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/pull/670%23issuecomment-82735950%22%2C%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/pull/670%23issuecomment-82736093%22%2C%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/pull/670%23issuecomment-83774639%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/SpiderOak/SpiderOakMobileClient/pull/670%23issuecomment-82735950%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Well.%5Cr%5Cn%5Cr%5CnThis%20is...%20disappointing%20%5B1%5D.%5Cr%5Cn%5Cr%5CnI%27d%20like%20at%20least%20hear%2C%20first%2C%20whether%20it%20would%20be%20feasible%20to%20quickly%20get%20email%20passwords%20and%20case%20insensitivity%20in%20direct%20Object%20Server%20based%20logins%2C%20before%20ditching%20all%20this%20heart%20warming%20%28and%20hard-earned%29%20simplification.%20For%20all%20we%20know%2C%20it%20may%20just%20amount%20to%20adjusting%20some%20SQL%20queries%20slightly.%20%40merickson%3F%5Cr%5Cn%5Cr%5CnIn%20any%20case%2C%20I%27ll%20examine%20the%20reversion%20closely%20tomorrow%2C%20and%20if%20there%27s%20no%20hope%20for%20quick%20revision%20of%20Object%20Server%2C%20see%20about%20accepting%20it.%5Cr%5Cn%5Cr%5Cn%28%5B1%5D%20%5C%22Disappointing%5C%22%20doesn%27t%20do%20it%20justice.%20However%2C%20a%20fine%20precedent%20is%20set%20by%20Zorg%2C%20the%20human%20villian%20in%20The%20Fifth%20Element%2C%20on%20at%20least%20one%20occasion%20where%20he%20utters%20this%20sentiment...%29%22%2C%20%22created_at%22%3A%20%222015-03-18T04%3A36%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/515685%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kenmanheimer%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28Oh%2C%20and%20big%20kudos%20to%20our%20royal%20PITA%20QA%20folk%20for%20catching%20these%20regressions%20-%20%40reneelynn%2C%20%40rebeccawatson.%29%22%2C%20%22created_at%22%3A%20%222015-03-18T04%3A38%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/515685%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kenmanheimer%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%27re%20going%20to%20work%20on%20enhancing%20object%20server%20for%20email%20case-insensitive%20logins%2C%20but%20will%20go%20with%20this%20for%20the%20immediate%20release.%22%2C%20%22created_at%22%3A%20%222015-03-19T22%3A00%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/515685%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kenmanheimer%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/670#issuecomment-82735950'>General Comment</a></b>
- <a href='https://github.com/kenmanheimer'><img border=0 src='https://avatars.githubusercontent.com/u/515685?v=3' height=16 width=16'></a> Well.
This is... disappointing [1].
I'd like at least hear, first, whether it would be feasible to quickly get email passwords and case insensitivity in direct Object Server based logins, before ditching all this heart warming (and hard-earned) simplification. For all we know, it may just amount to adjusting some SQL queries slightly. @merickson?
In any case, I'll examine the reversion closely tomorrow, and if there's no hope for quick revision of Object Server, see about accepting it.
([1] "Disappointing" doesn't do it justice. However, a fine precedent is set by Zorg, the human villian in The Fifth Element, on at least one occasion where he utters this sentiment...)
- <a href='https://github.com/kenmanheimer'><img border=0 src='https://avatars.githubusercontent.com/u/515685?v=3' height=16 width=16'></a> (Oh, and big kudos to our royal PITA QA folk for catching these regressions - @reneelynn, @rebeccawatson.)
- <a href='https://github.com/kenmanheimer'><img border=0 src='https://avatars.githubusercontent.com/u/515685?v=3' height=16 width=16'></a> We're going to work on enhancing object server for email case-insensitive logins, but will go with this for the immediate release.


<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/670?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/670?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/670'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>