### PR TITLE
SpiderOak___ vs SpiderOak ___

### DIFF
--- a/custom/brand_elements.json
+++ b/custom/brand_elements.json
@@ -29,6 +29,11 @@
         "field": "projectName",
         "tagPath": "./application/activity",
         "attribute": "android:name"
+      },
+      {
+        "field": "brandName",
+        "tagPath": "./application/activity",
+        "attribute": "android:label"
       }
     ]
   },


### PR DESCRIPTION
Use brandName for Android label

This needs testing. Especially with the long name of "SpiderOak Blackphone Edition" and in iOS.

Consider this PR a WIP

Fixes #634
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/677?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/677'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>