### PR TITLE
Use correct brackets around translated string.

### DIFF
--- a/www/locales/fr.json
+++ b/www/locales/fr.json
@@ -233,5 +233,5 @@
 	"Keep it": "Le conserver",
 	"Error removing favorite from device (error code: [[code]])": "Erreur lors de la suppression d'un favori sur l'appareil (code d'erreur : {{code}})",
 	"It does not currently provide upload or sync capability.": "Actuellement, pas de capacité de téléchargement ni de synchronisation.",
-	"In order to ensure [[Zero-Knowledge]] Privacy, your account must be created on a computer.": "Afin de garantir un niveau de confidentialité [[Zero-Knowledge]], vous devez créer votre compte sur un ordinateur."
+	"In order to ensure [[Zero-Knowledge]] Privacy, your account must be created on a computer.": "Afin de garantir un niveau de confidentialité {{Zero-Knowledge}}, vous devez créer votre compte sur un ordinateur."
 }


### PR DESCRIPTION
Fixes #675
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/678?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/678'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>