### PR TITLE
issue 699 - BPC 3.3.0 Advanced Login Settings is redundant

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -164,6 +164,9 @@
         spiderOakApp.loginView.$(".learn-more").show();
         spiderOakApp.loginView.$(".advanced-login-settings").show();
       }
+      if (spiderOakApp.settings.getOrDefault("inhibitAdvancedLogin")) {
+        spiderOakApp.loginView.$(".advanced-login-settings").hide();
+      }
       // Determine if we should be showing the preliminary screen at all
       spiderOakApp.showPreliminary = false;
       if (spiderOakApp.settings.getOrDefault("showPreliminary")) {


### PR DESCRIPTION
Hides "advanced login settings" link if inhibitAdvancedLogin setting is true

Fixes #699
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/SpiderOak/SpiderOakMobileClient/pull/704?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/SpiderOak/SpiderOakMobileClient/pull/704'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>