### PR TITLE
Fixed CFBundleVersion to use 24hs format.

### DIFF
--- a/.cordova/hooks/after_prepare/version.js
+++ b/.cordova/hooks/after_prepare/version.js
@@ -65,7 +65,7 @@
     package.pop();
     package.push(projectConfig.projectName);
     infoPlist['CFBundleIdentifier'] = package.join(".");
-    infoPlist['CFBundleVersion'] = moment().format('YYYYMMDDhhmm');
+    infoPlist['CFBundleVersion'] = moment().format('YYYYMMDDkkmm');
     infoPlist['CFBundleShortVersionString'] = version;
     infoPlist['CFBundleDisplayName'] = shortDisplayName;
     var info_contents = plist.build(infoPlist);


### PR DESCRIPTION
A small change in the hook that sets the CFBundleVersion property. It now uses 24h format, otherwise there's sadness when you build several times a day.