### PR TITLE
Changed project name to Groups.

### DIFF
--- a/custom/brands/Groups/custom_config.js
+++ b/custom/brands/Groups/custom_config.js
@@ -7,10 +7,9 @@
  */
 
 window.spiderOakMobile_custom_config = {
-  app_label: {value: "SpiderOak Blue", retain: 1},
+  app_label: {value: "Groups", retain: 1},
   showPreliminary: {value: false, retain: 0},
   server: {value: "spideroak.com", retain: 1},
   inhibitAdvancedLogin: {value: false, retain: 0},
   contactEmail: {value: "groups@spideroak.com", retain: 0}
 };
-


### PR DESCRIPTION
Change "SpiderOak Blue" project name to "Groups" to prevent a naming issue in Android 6 and previous.

The app name for iOS has been changed in the Apple Developer Center to reflect this.