### PR TITLE
Grab iOS app ID from config instead of parsing package.json

### DIFF
--- a/.cordova/hooks/after_prepare/version.js
+++ b/.cordova/hooks/after_prepare/version.js
@@ -64,7 +64,7 @@
     var package = config.getroot().attrib.id.split(".");
     package.pop();
     package.push(projectConfig.projectName);
-    infoPlist['CFBundleIdentifier'] = package.join(".");
+    infoPlist['CFBundleIdentifier'] = projectConfig.iosIdentifier;
     infoPlist['CFBundleVersion'] = moment().format('YYYYMMDDkkmm');
     infoPlist['CFBundleShortVersionString'] = version;
     infoPlist['CFBundleDisplayName'] = shortDisplayName;

--- a/custom/brands/Groups/project_config.json
+++ b/custom/brands/Groups/project_config.json
@@ -1,7 +1,7 @@
 {
   "whatsthis": "/* SpiderOak Blue-label project configuration. */",
 
-  "projectName": "SpiderOakBlue",
+  "projectName": "Groups",
   "displayName": "SpiderOak Groups",
   "shortDisplayName": "Groups",
   "brandName": "SpiderOak Groups",


### PR DESCRIPTION
Another string change for SpiderOak Groups. Correctly set CFBundleIdentifier property for iOS.